### PR TITLE
Use AWS MimeType library to determine the Content-Type of the uploaded file.

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -9,6 +9,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.internal.Mimetypes;
 
 public class S3Profile {
     private String name;
@@ -71,13 +73,13 @@ public class S3Profile {
         
         final Destination dest = new Destination(bucketName,filePath.getName());
         
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(Mimetypes.getInstance().getMimetype(filePath.getName()));
+                
         try {
-            getClient().putObject(dest.bucketName, dest.objectName, filePath.read(), /*metadata=*/null);
+            getClient().putObject(dest.bucketName, dest.objectName, filePath.read(), metadata);
         } catch (Exception e) {
             throw new IOException("put " + dest + ": " + e);
         }
     }
-    
- 
-    
 }


### PR DESCRIPTION
Prior to this change, all files were uploaded to S3 with the application/octect-stream Content-Type.  For people that use this plugin to publish website artifacts, this causes browsers to incorrectly interpret *.html, *.css, etc. files.  This change utilizes the MimeType class in the AWS library to attempt to infer a Mime-Type from the target file's extension.  If no match is found, then the library defaults to application/octet-stream, so present compatibility should be maintained.
