### PR TITLE
JENKINS-13531 Change escape to encodeURIcomponent so that plus chars are converted

### DIFF
--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -10,7 +10,7 @@
           <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
             <f:textbox name="s3.accessKey" value="${profile.accessKey}"
                        checkMethod="post"
-                       checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+escape(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+escape(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+escape(this.value)"
+                       checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)"
             />
           </f:entry>
           <f:entry title="Secret key" help="/plugin/s3/help-secretkey.html">


### PR DESCRIPTION
Change escape to encodeURIcomponent so that plus chars are converted
correctly for s3 secret and access key

https://issues.jenkins-ci.org/browse/JENKINS-13531
[FIXED JENKINS-13531]
