### PR TITLE
Add S3 user metadata to uploads.

### DIFF
--- a/src/main/java/hudson/plugins/s3/MetadataPair.java
+++ b/src/main/java/hudson/plugins/s3/MetadataPair.java
@@ -1,0 +1,14 @@
+package hudson.plugins.s3;
+
+public final class MetadataPair {
+    /**
+     * The key of the user metadata pair to tag an upload with.
+     * Can contain macros.
+     */
+    public String key;
+    /**
+     * The key of the user metadata pair to tag an upload with.
+     * Can contain macros.
+     */
+    public String value;
+}

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -3,6 +3,7 @@ package hudson.plugins.s3;
 import hudson.FilePath;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -66,7 +67,8 @@ public class S3Profile {
     
     
    
-    public void upload(String bucketName, FilePath filePath) throws IOException, InterruptedException {
+    public void upload(String bucketName, FilePath filePath, List<MetadataPair> userMetadata)
+            throws IOException, InterruptedException {
         if (filePath.isDirectory()) {
             throw new IOException(filePath + " is a directory");
         }
@@ -76,6 +78,9 @@ public class S3Profile {
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(Mimetypes.getInstance().getMimetype(filePath.getName()));
         metadata.setContentLength(filePath.length());
+        for (MetadataPair metadataPair : userMetadata) {
+            metadata.addUserMetadata(metadataPair.key, metadataPair.value);
+        }
         try {
             getClient().putObject(dest.bucketName, dest.objectName, filePath.read(), metadata);
         } catch (Exception e) {

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -29,4 +29,22 @@
       </table>
     </f:repeatable>
   </f:entry>
+
+  <f:entry title="Metadata tags">
+    <f:repeatable var="m" items="${instance.userMetadata}">
+      <table width="100%">
+        <f:entry title="Metadata key" help="${helpURL}/help-key.html">
+          <f:textbox name="s3.metadataPair.key" value="${m.key}" />
+        </f:entry>
+        <f:entry title="Metadata value" help="${helpURL}/help-value.html">
+          <f:textbox name="s3.metadataPair.value" value="${m.value}" />
+        </f:entry>
+          <f:entry title="">
+          <div align="right">
+            <f:repeatableDeleteButton />
+          </div>
+        </f:entry>
+      </table>
+    </f:repeatable>
+  </f:entry>
 </j:jelly>

--- a/src/main/webapp/help-key.html
+++ b/src/main/webapp/help-key.html
@@ -1,0 +1,5 @@
+<div>
+    Metadata key for the files from this build. It will be prefixed by
+    "x-amz-meta-" when uploaded to S3. Can contain macros (e.g. environment
+    variables).
+</div>

--- a/src/main/webapp/help-value.html
+++ b/src/main/webapp/help-value.html
@@ -1,0 +1,4 @@
+<div>
+    Metadata value for the files from this build. Can contain macros (e.g.
+    environment variables).
+</div>


### PR DESCRIPTION
![Screen shot 2013-03-15 at 3 36 54 PM](https://f.cloud.github.com/assets/873857/265220/6af30dc0-8da8-11e2-8add-4f0588ec6588.png)
S3 uploads can be tagged with user metadata in the form of key-value
pairs. Add a config option on a project-by-project basis to tag uploads
with this metadata.

This is most useful when the metadata includes Jenkins macros–for
instance, we plan to use it to tag build uploads with the branch of the
build.

The option is project-by-project rather than file-by-file due to
Jenkins/Jelly issues with nested <f:repeatable> elements.
