### PR TITLE
Update to AWS API 1.3.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.20</version>
+            <version>1.3.21</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This supports the com.amazonaws.sdk.s3.defaultStreamBufferSize property.

See https://issues.jenkins-ci.org/browse/JENKINS-15677
