### PR TITLE
[FIXED JENKINS-14395] Protected the S3 secret key

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -11,11 +11,12 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.internal.Mimetypes;
+import hudson.util.Secret;
 
 public class S3Profile {
     private String name;
     private String accessKey;
-    private String secretKey;
+    private Secret secretKey;
     private static final AtomicReference<AmazonS3Client> client = new AtomicReference<AmazonS3Client>(null);
 
     public S3Profile() {
@@ -25,7 +26,7 @@ public class S3Profile {
     public S3Profile(String name, String accessKey, String secretKey) {
         this.name = name;
         this.accessKey = accessKey;
-        this.secretKey = secretKey;
+        this.secretKey = Secret.fromString(secretKey);
         client.set(new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey)));
     }
 
@@ -37,12 +38,8 @@ public class S3Profile {
         this.accessKey = accessKey;
     }
 
-    public final String getSecretKey() {
+    public final Secret getSecretKey() {
         return secretKey;
-    }
-
-    public void setSecretKey(String secretKey) {
-        this.secretKey = secretKey;
     }
 
     public final String getName() {
@@ -55,7 +52,7 @@ public class S3Profile {
 
     public AmazonS3Client getClient() {
         if (client.get() == null) {
-            client.set(new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey)));
+            client.set(new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey.getPlainText())));
         }
         return client.get();
     }


### PR DESCRIPTION
The S3 secret key is stored in the clear and is also passed over the wire in the clear.  This fix uses hudson.util.Secret to obfuscate the key in both the configuration file and across the wire. 
