### PR TITLE
Updated AWS SDK to latest stable from 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.26</version>
+            <version>1.4.7</version>
             <exclusions>
               <exclusion>
                 <groupId>commons-codec</groupId>


### PR DESCRIPTION
This helps in our environment to over the buffer problems encountered with AWS SDK 1.3

Publish artifacts to S3 Bucket bucket=foo, file=bar-1.0.0-395746_20130711184057.tar.gz
ERROR: Failed to upload files
java.io.IOException: put Destination [bucketName=foo, objectName=bar/bar-1.0.0-395746_20130711184057.tar.gz]: com.amazonaws.AmazonClientException: Unable to execute HTTP request: Input stream cannot be reset as 31571968 bytes have been written, exceeding the available buffer size of 131072
        at hudson.plugins.s3.S3Profile.upload(S3Profile.java:82)
        at hudson.plugins.s3.S3BucketPublisher.perform(S3BucketPublisher.java:119)
        at hudson.tasks.BuildStepMonitor$2.perform(BuildStepMonitor.java:27)
        at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:802)
        at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:774)
        at hudson.model.Build$BuildExecution.post2(Build.java:183)
        at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:724)
        at hudson.model.Run.execute(Run.java:1600)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
        at hudson.model.ResourceController.execute(ResourceController.java:88)
        at hudson.model.Executor.run(Executor.java:237)
Build step 'Publish artifacts to S3 Bucket' changed build result to UNSTABLE
