### PR TITLE
JENKINS-21594: Allow to upload file without wildcard

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -214,7 +214,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
         }
         else
         {
-            return pathWithFilter.length();
+            return file2.getParent().length() + 1;
         }
     }
 


### PR DESCRIPTION
Commit 24a3b88a7b9acb0532deabe686944e53747c49a9 introduced a feature for wildcard uploads, but broke
the original behavior if your upload is configured with a straight
filename.

For instance:
Destination bucket: path/to/dir
Source: file.tar.gz

Would be uploaded as path/to/dir, missing completely the source file name.

This commit fixes this specific issue.

This is tracked in:
https://issues.jenkins-ci.org/browse/JENKINS-21594
