### PR TITLE
allow configuring of ContentEncoding, CacheControl, ExpirationTimeRuleId

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -48,4 +48,20 @@ public final class Entry {
      * Use S3 server side encryption when uploading the artifacts
      */
     public boolean useServerSideEncryption;
+	
+	/**
+	 * Content-Encoding HTTP header
+	 **/
+	public String encoding;
+	
+	/**
+	 * Cache-Control HTTP header
+	 **/
+	public String cacheControl;
+		
+	/**
+	 * BucketLifecycleConfiguration rule ID for the objects' expiration
+	 **/
+	public String expirationTimeRuleId;
+	
 }

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -170,8 +170,8 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
                 List<FingerprintRecord> records = Lists.newArrayList();
                 
                 for (FilePath src : paths) {
-                    log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.managedArtifacts + " , server encryption "+entry.useServerSideEncryption);
-                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts,entry.useServerSideEncryption ));
+                    log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.managedArtifacts + " , server encryption " + entry.useServerSideEncryption + " , encoding=" + entry.encoding + " , cacheControl=" + entry.cacheControl + " , expirationTimeRuleId=" + entry.expirationTimeRuleId);
+                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.encoding, entry.cacheControl, entry.expirationTimeRuleId ));
                 }
                 if (entry.managedArtifacts) {
                     artifacts.addAll(records);

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -114,7 +114,7 @@ public class S3Profile {
     }
 
     public FingerprintRecord upload(AbstractBuild<?,?> build, final BuildListener listener, String bucketName, FilePath filePath, int searchPathLength, List<MetadataPair> userMetadata,
-            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts,boolean useServerSideEncryption) throws IOException, InterruptedException {
+            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts,boolean useServerSideEncryption, String encoding, String cacheControl, String expirationTimeRuleId) throws IOException, InterruptedException {
         if (filePath.isDirectory()) {
             throw new IOException(filePath + " is a directory");
         }
@@ -130,7 +130,7 @@ public class S3Profile {
         }
 
         try {
-            S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
+            S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion,useServerSideEncryption, encoding, cacheControl, expirationTimeRuleId);
             if (uploadFromSlave) {
                 return filePath.act(callable);
             } else {

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -23,14 +23,17 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 public class S3UploadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> {
     private static final long serialVersionUID = 1L;
     private final Destination dest;
-    private final String storageClass;
+    private final String storageClass;	
     private final List<MetadataPair> userMetadata;
     private final String selregion;
     private final boolean produced;
     private final boolean useServerSideEncryption;
+	private final String encoding;
+	private final String cacheControl;
+	private final String expirationTimeRuleId;
 
     public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
-            String selregion, boolean useServerSideEncryption) {
+            String selregion, boolean useServerSideEncryption, String encoding, String cacheControl, String expirationTimeRuleId) {
         super(accessKey, secretKey, useRole);
         this.dest = dest;
         this.storageClass = storageClass;
@@ -38,6 +41,9 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
         this.selregion = selregion;
         this.produced = produced;
         this.useServerSideEncryption = useServerSideEncryption;
+		this.encoding = encoding;
+		this.cacheControl = cacheControl;
+		this.expirationTimeRuleId = expirationTimeRuleId;
     }
 
     public ObjectMetadata buildMetadata(FilePath filePath) throws IOException, InterruptedException {
@@ -55,6 +61,19 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
         for (MetadataPair metadataPair : userMetadata) {
             metadata.addUserMetadata(metadataPair.key, metadataPair.value);
         }
+		
+		if ((encoding != null) && !"".equals(encoding)) {
+			metadata.setContentEncoding(encoding);
+		}
+		
+		if ((cacheControl != null) && !"".equals(cacheControl)) {
+			metadata.setCacheControl(cacheControl);
+		}
+				
+		if ((expirationTimeRuleId != null) && !"".equals(expirationTimeRuleId)) {
+			metadata.setExpirationTimeRuleId(expirationTimeRuleId);
+		}
+	
         return metadata;
     }
 

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -46,6 +46,22 @@
         <f:entry field="useServerSideEncryption" title="Server side encryption" help="${helpURL}/help-server-encryption.html">
 		    <f:checkbox name="s3.entry.useServerSideEncryption" checked="${e.useServerSideEncryption}"/>
         </f:entry>
+		
+		<f:entry title="Content Encoding" help="${helpURL}/help-content-encoding.html">
+          <input class="setting-input" name="s3.entry.encoding"
+            type="text" value="${e.encoding}" />
+        </f:entry>
+		
+		<f:entry title="Cache Control" help="${helpURL}/help-cache-control.html">
+          <input class="setting-input" name="s3.entry.cacheControl"
+            type="text" value="${e.cacheControl}" />
+        </f:entry>
+				
+		<f:entry title="Expiration time rule" help="${helpURL}/help-expiration-time-rule.html">
+          <input class="setting-input" name="s3.entry.expirationTimeRuleId"
+            type="text" value="${e.expirationTimeRuleId}" />
+        </f:entry>
+		
         <f:entry title="">
           <div align="right">
             <f:repeatableDeleteButton />

--- a/src/main/webapp/help-cache-control.html
+++ b/src/main/webapp/help-cache-control.html
@@ -1,0 +1,4 @@
+<div>
+Sets the optional Cache-Control HTTP header which allows the user to specify caching behavior along the HTTP request/reply chain.
+For more information on how the Cache-Control HTTP header affects HTTP requests and responses see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
+</div>

--- a/src/main/webapp/help-content-encoding.html
+++ b/src/main/webapp/help-content-encoding.html
@@ -1,0 +1,4 @@
+<div>
+Sets the optional Content-Encoding HTTP header specifying what content encodings have been applied to the object and what decoding mechanisms must be applied in order to obtain the media-type referenced by the Content-Type field.
+For more information on how the Content-Encoding HTTP header works, see <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+</div>

--- a/src/main/webapp/help-expiration-time-rule.html
+++ b/src/main/webapp/help-expiration-time-rule.html
@@ -1,0 +1,1 @@
+<div>Sets the bucket lifecycle configuration rule ID for the objects' expiration</div>


### PR DESCRIPTION
I'm uploading gzipped content to S3 so I need to set the ContentEncoding to 'gzip' when uploading.

I also added configuration for other setters of [ObjectMetadata](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/ObjectMetadata.html): [setCacheControl](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/ObjectMetadata.html#setCacheControl%28java.lang.String%29), [setExpirationTimeRuleId](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/ObjectMetadata.html#setExpirationTimeRuleId%28java.lang.String%29).

I couldn't do [setHttpExpiresDate](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/ObjectMetadata.html#setHttpExpiresDate%28java.util.Date%29) (I'm really rust at Java). But it'd be really nice if someone could implement it as well.

This solves [JENKINS-23441](https://issues.jenkins-ci.org/browse/JENKINS-23441) I opened today.
