### PR TITLE
Make S3 signed URL expiry configurable, with 60s default

### DIFF
--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -38,6 +38,12 @@
               <f:repeatableDeleteButton />
             </div>
           </f:entry>
+          <f:advanced>
+            <f:entry title="Download URL expiry (seconds)" help="/plugin/s3/help-signedUrlExpirySeconds.html">
+              <f:number clazz="positive-number" name="s3.signedUrlExpirySeconds"
+                        value="${profile.signedUrlExpirySeconds}" default="60" />
+            </f:entry>
+          </f:advanced>
         </table>
       </f:repeatable>
     </f:entry>

--- a/src/main/webapp/help-signedUrlExpirySeconds.html
+++ b/src/main/webapp/help-signedUrlExpirySeconds.html
@@ -1,0 +1,1 @@
+<div>When a user downloads an S3 artifact, Jenkins generates a signed URL to let them download it directly from S3. This URL lets anybody who knows the URL download the URL until it expires. Short expiry times prevent people from sharing the URL as easily but mean that the server's clock has to be synced to make sure it generates valid URLs.</div>


### PR DESCRIPTION
Per JENKINS-23897, S3 signed URLs for downloads were very sensitive to server
clock drift / time sync issues. The hardcoded 4 second expiry was too short even
if the server time was accurate if Jenkins took a moment to respond and/or
the request to S3 took a moment. On high latency links like 3G downloads frequently
failed.

Make the timeout configurable under Advanced, and default to 60 seconds instead
of 4.
