### PR TITLE
added names to entries and userData f:repeatable tag to establish bindin...

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -62,7 +62,7 @@ public final class Entry extends AbstractDescribableImpl<Entry> {
 
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String storageClass, String selectedRegion, boolean noUploadOnFailure,
-            boolean uploadFromSlave, boolean managedArtifacts) {
+            boolean uploadFromSlave, boolean managedArtifacts, boolean useServerSideEncryption, boolean flatten) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.storageClass = storageClass;
@@ -70,6 +70,8 @@ public final class Entry extends AbstractDescribableImpl<Entry> {
         this.noUploadOnFailure = noUploadOnFailure;
         this.uploadFromSlave = uploadFromSlave;
         this.managedArtifacts = managedArtifacts;
+        this.useServerSideEncryption = useServerSideEncryption;
+        this.flatten = flatten;
     }
 
     @Extension

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -10,7 +10,7 @@
     </f:entry>
 
   <f:entry title="Files to upload">
-    <f:repeatable var="e" items="${instance.entries}">
+    <f:repeatable var="e" items="${instance.entries}" name="entries">
       <table width="100%">
         <f:entry title="Source" help="${helpURL}/help-source.html">
           <input class="setting-input" name="s3.entry.sourceFile"
@@ -59,7 +59,7 @@
   </f:entry>
 
   <f:entry title="Metadata tags">
-    <f:repeatable var="m" items="${instance.userMetadata}">
+    <f:repeatable var="m" items="${instance.userMetadata}" name="userMetadata">
       <table width="100%">
         <f:entry title="Metadata key" help="${helpURL}/help-key.html">
           <f:textbox name="s3.metadataPair.key" value="${m.key}" />


### PR DESCRIPTION
File upload and Metadata configuration were not being saved as null was being passed into the S3BucketPublisher constructor.  The name attributes on the f:repeatable tags were missing.  This patch added the missing attributes.