### PR TITLE
Fix proxy config not echoed to config UI and not read during upload/download

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -143,7 +143,7 @@ public class S3Profile {
         }
 
         try {
-            S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
+            S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, proxyHost, proxyPort, useRole, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
             if (uploadFromSlave) {
                 return filePath.act(callable);
             } else {
@@ -194,7 +194,7 @@ public class S3Profile {
                   Destination dest = Destination.newFromRun(build, artifact);
                   FilePath target = new FilePath(targetDir, artifact.getName());
                   try {
-                      fingerprints.add(target.act(new S3DownloadCallable(accessKey, secretKey, useRole, dest, console)));
+                      fingerprints.add(target.act(new S3DownloadCallable(accessKey, secretKey, proxyHost, proxyPort, useRole, dest, console)));
                   } catch (IOException e) {
                       e.printStackTrace();
                   } catch (InterruptedException e) {

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -79,6 +79,14 @@ public class S3Profile {
         this.name = name;
     }
 
+    public final String getProxyHost() {
+        return this.proxyHost;
+    }
+
+    public final String getProxyPort() {
+        return this.proxyPort;
+    }
+
     public final boolean getUseRole() {
         return this.useRole;
     }

--- a/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
@@ -4,6 +4,7 @@ import hudson.util.Secret;
 
 import java.io.Serializable;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
 
@@ -13,13 +14,17 @@ public class AbstractS3Callable implements Serializable
 
     private final String accessKey;
     private final Secret secretKey;
+    private final String proxyHost;
+    private final String proxyPort;
     private final boolean useRole;
     private transient AmazonS3Client client;
 
-    public AbstractS3Callable(String accessKey, Secret secretKey, boolean useRole) 
+    public AbstractS3Callable(String accessKey, Secret secretKey, String proxyHost, String proxyPort, boolean useRole) 
     {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
+        this.proxyHost = proxyHost;
+        this.proxyPort = proxyPort;
         this.useRole = useRole;
     }
 
@@ -27,12 +32,21 @@ public class AbstractS3Callable implements Serializable
     {
         if (client == null) {
             if (useRole) {
-                client = new AmazonS3Client();
+                client = new AmazonS3Client(getClientConfiguration());
             } else {
-                client = new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey.getPlainText()));
+                client = new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey.getPlainText()), getClientConfiguration());
             }
         }
         return client;
+    }
+
+    private ClientConfiguration getClientConfiguration(){
+        final ClientConfiguration clientConfiguration = new ClientConfiguration();
+        if(proxyHost != null && proxyHost.length() > 0) {
+            clientConfiguration.setProxyHost(proxyHost);
+            clientConfiguration.setProxyPort(Integer.parseInt(proxyPort));
+        }
+        return clientConfiguration;
     }
 
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -19,9 +19,9 @@ public class S3DownloadCallable extends AbstractS3Callable implements FileCallab
     final private Destination dest;
     final transient private PrintStream log;
     
-    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, PrintStream console) 
+    public S3DownloadCallable(String accessKey, Secret secretKey, String proxyHost, String proxyPort, boolean useRole, Destination dest, PrintStream console) 
     {
-        super(accessKey, secretKey, useRole);
+        super(accessKey, secretKey, proxyHost, proxyPort, useRole);
         this.dest = dest;
         this.log = console;
     }

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -29,9 +29,9 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     private final boolean produced;
     private final boolean useServerSideEncryption;
 
-    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
+    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, String proxyHost, String proxyPort, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
             String selregion, boolean useServerSideEncryption) {
-        super(accessKey, secretKey, useRole);
+        super(accessKey, secretKey, proxyHost, proxyPort, useRole);
         this.dest = dest;
         this.storageClass = storageClass;
         this.userMetadata = userMetadata;

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -13,7 +13,7 @@
             <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
               <f:textbox name="s3.accessKey" value="${profile.accessKey}"
                          checkMethod="post"
-                         checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)"
+                         checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)+'&amp;proxyHost='+encodeURIComponent(Form.findMatchingInput(this,'s3.proxyHost').value)+'&amp;proxyPort='+encodeURIComponent(Form.findMatchingInput(this,'s3.proxyPort').value)"
               />
             </f:entry>
             <f:entry title="Secret key" help="/plugin/s3/help-secretkey.html">
@@ -26,11 +26,13 @@
           <f:entry title="Proxy Host" help="/plugin/s3/help-proxyHost.html">
             <input class="setting-input" name="s3.proxyHost"
                    value="${profile.proxyHost}"
+                   onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()"
             />
           </f:entry>
           <f:entry title="Proxy Port" help="/plugin/s3/help-proxyPort.html">
             <input class="setting-input" name="s3.proxyPort"
                    value="${profile.proxyPort}"
+                   onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()"
             />
           </f:entry>
           <f:entry title="">


### PR DESCRIPTION
Due to missing getters on S3Profile, configured proxies were not echoed to fields in config UI, so saving subsequent config changes erased proxy settings.
Fix proxies not using during config testing while editing in config UI.
Fix proxy settings not being passed to AbstractS3Callable, thus were not being used during actual file transfer.