### PR TITLE
Update AWS SDK to 1.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.7.8</version>
+            <version>1.9.7</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
In order to support the EU_CENTRAL_1 region this version is needed.
