### PR TITLE
[JENKINS-24722] Checkbox to disable waiting on concurrent build completion for publishing

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -45,13 +45,16 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
 
     private final List<Entry> entries;
 
+    private boolean dontWaitForConcurrentBuildCompletion;
+
     /**
      * User metadata key/value pairs to tag the upload with.
      */
     private /*almost final*/ List<MetadataPair> userMetadata;
 
     @DataBoundConstructor
-    public S3BucketPublisher(String profileName, List<Entry> entries, List<MetadataPair> userMetadata) {
+    public S3BucketPublisher(String profileName, List<Entry> entries, List<MetadataPair> userMetadata,
+                             boolean dontWaitForConcurrentBuildCompletion) {
         if (profileName == null) {
             // defaults to the first one
             S3Profile[] sites = DESCRIPTOR.getProfiles();
@@ -65,6 +68,8 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
         if (userMetadata==null)
             userMetadata = new ArrayList<MetadataPair>();
         this.userMetadata = userMetadata;
+
+        this.dontWaitForConcurrentBuildCompletion = dontWaitForConcurrentBuildCompletion;
     }
 
     protected Object readResolve() {
@@ -85,6 +90,9 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
         return this.profileName;
     }
 
+    public boolean isDontWaitForConcurrentBuildCompletion() {
+        return dontWaitForConcurrentBuildCompletion;
+    }
 
     public S3Profile getProfile() {
         return getProfile(profileName);
@@ -234,7 +242,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
     }
    
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.STEP;
+        return dontWaitForConcurrentBuildCompletion ? BuildStepMonitor.NONE : BuildStepMonitor.STEP;
     }
 
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -24,4 +24,8 @@
         </f:entry>
     </f:repeatableProperty>
   </f:entry>
+
+  <f:entry field="dontWaitForConcurrentBuildCompletion" title="">
+    <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3" />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-dontWaitForConcurrentBuildCompletion.html
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-dontWaitForConcurrentBuildCompletion.html
@@ -1,0 +1,5 @@
+<div>
+    When disabled, only publish to S3 after completion of concurrent builds to prevent overriding published artifact. You
+    can enable this to publish to S3 at the end of each concurrent build. Published artifact should then have a
+    different name for each build to prevent unnecessary uploads.
+</div>


### PR DESCRIPTION
Let the user choose whether or not he wants to wait for completion of concurrent builds before publishing to S3. The current behavior is not adequate if the published artifact name on S3 is different for each build.