### PR TITLE
Fix region enum

### DIFF
--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -120,10 +120,10 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     }
 
     private void setRegion() {
-        // In 0.7, selregion uses Regions#name
+        // In 0.7, selregion comes from Regions#name
         Region region = RegionUtils.getRegion(selregion);
 
-        // In 0.6, selregion uses Regions#valueOf
+        // In 0.6, selregion comes from Regions#valueOf
         if (region == null) {
             region = RegionUtils.getRegion(Regions.valueOf(selregion).getName());
         }

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -120,7 +120,14 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     }
 
     private void setRegion() {
-        Region region = RegionUtils.getRegion(Regions.fromName(selregion).getName());
+        // In 0.7, selregion uses Regions#name
+        Region region = RegionUtils.getRegion(selregion);
+
+        // In 0.6, selregion uses Regions#valueOf
+        if (region == null) {
+            region = RegionUtils.getRegion(Regions.valueOf(selregion).getName());
+        }
+
         getClient().setRegion(region);
     }
 }


### PR DESCRIPTION
In 0.7, the change to Region lookup broke backwards compatibility with previous versions. This broke the s3 plugin for [job-dsl-plugin](https://github.com/jenkinsci/job-dsl-plugin/).

This diff provides backwards compatibility by allowing both approaches to lookup the Region. Perhaps a deprecation period would be useful.

Ref: https://github.com/jenkinsci/job-dsl-plugin/pull/346