### PR TITLE
Improved artifact management

### DIFF
--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -1,63 +1,115 @@
 package hudson.plugins.s3;
 
-import hudson.model.AbstractBuild;
-import hudson.model.Run;
-
 import java.io.Serializable;
-
+import hudson.FilePath;
 
 /**
  * Provides a way to construct a destination bucket name and object name based
  * on the bucket name provided by the user.
- * 
+ *
  * The convention implemented here is that a / in a bucket name is used to
  * construct a structure in the object name.  That is, a put of file.txt to bucket name
  * of "mybucket/v1" will cause the object "v1/file.txt" to be created in the mybucket.
- * 
+ *
  */
 public class Destination implements Serializable {
-  private static final long serialVersionUID = 1L;
-  public final String bucketName; 
-  public final String objectName; 
-  
-  public Destination(final String userBucketName, final String fileName) {
-    
-    if (userBucketName == null || fileName == null) 
-      throw new IllegalArgumentException("Not defined for null parameters: "+userBucketName+","+fileName);
-    
-    final String[] bucketNameArray = userBucketName.split("/", 2);
-    
-    bucketName = bucketNameArray[0];
-    
-    if (bucketNameArray.length > 1) {
-        objectName = bucketNameArray[1] + "/" + fileName;
-    } else {
-        objectName = fileName;
+    private static final long serialVersionUID = 1L;
+    public String bucketName;
+    public String userBucketName;
+    public String fileName;
+    public String objectName;
+
+    /*
+     * Create a Destination with unmanaged artifacts
+     * @param userBucketName
+     * @param fileName
+     */
+    public Destination(String userBucketName, String fileName) {
+
+        initialize(userBucketName, fileName, "");
     }
-  }
 
-@Override
- public String toString() {
-   return "Destination [bucketName="+bucketName+", objectName="+objectName+"]";
- }
-  
+    /*
+     * Create a Destination with managed artifacts
+     * @param projectName
+     * @param buildId
+     * @param bucketName
+     * @param fileName
+     */
+    public Destination(String projectName, int buildId, String bucketName, String fileName) {
 
-  public static Destination newFromRun(Run run, String bucketName, String fileName)
-  {
-    String projectName = run.getParent().getName();
-    int buildID = run.getNumber();
-    return new Destination(bucketName, "jobs/" + projectName + "/" + buildID + "/" + fileName);
-  }
+        initialize(bucketName, fileName, getManagedPrefix(projectName, buildId));
+    }
 
-  public static Destination newFromRun(Run run, S3Artifact artifact) 
-  {
-    return newFromRun(run, artifact.getBucket(), artifact.getName());
-  }
-    
-  public static Destination newFromBuild(AbstractBuild<?, ?> build, String bucketName, String fileName)
-  {
-    String projectName = build.getParent().getName();
-    int buildID =build.getNumber();
-    return new Destination(bucketName, "jobs/" + projectName + "/" + buildID + "/" + fileName);
-  }
+    /*
+     * Create a Destination with conditionally managed artifacts
+     * @param projectName
+     * @param buildId
+     * @param bucketName
+     * @param filePath
+     * @param searchPathLength
+     * @param artifactManagement
+     */
+    public Destination(String projectName, int buildId, String bucketName, FilePath filePath,
+                       int searchPathLength, String artifactManagement) {
+
+        String fileName;
+        if (Entry.isStructured(artifactManagement)) {
+            fileName = filePath.getRemote().substring(searchPathLength);
+        }
+        else {
+            fileName = filePath.getName();
+        }
+
+        if (Entry.isManaged(artifactManagement)) {
+            initialize(bucketName, fileName, getManagedPrefix(projectName, buildId));
+        }
+        else {
+            initialize(bucketName, fileName, "");
+        }
+    }
+
+    private String getManagedPrefix(String projectName, int buildID) {
+
+        return "jobs/" + projectName + "/" + buildID + "/";
+    }
+
+    private void initialize(final String userBucketName, final String fileName, String pathPrefix) {
+
+        if (userBucketName == null || fileName == null)
+            throw new IllegalArgumentException("Not defined for null parameters: " + userBucketName + "," + fileName);
+
+        final String[] bucketNameArray = userBucketName.split("/", 2);
+
+        bucketName = bucketNameArray[0];
+        this.userBucketName = userBucketName;
+        this.fileName = fileName;
+
+        if (bucketNameArray.length > 1) {
+            this.objectName = bucketNameArray[1] + "/" + pathPrefix + fileName;
+        } else {
+            this.objectName = pathPrefix + fileName;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Destination [bucketName=" + bucketName + ", objectName=" + objectName + "]";
+    }
+
+    public String getUserBucketName() {
+        return userBucketName;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public String getObjectName() {
+        return objectName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
 }

--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -46,6 +46,21 @@ public final class Entry implements Describable<Entry> {
     public boolean uploadFromSlave;
 
     /**
+     * Artifact management options. Managed by Jenkins or by owner.
+     */
+    public enum managedArtifactsEnum {
+        UNMANAGED_FLATTENED,
+        UNMANAGED_STRUCTURED,
+        MANAGED_FLATTENED,
+        MANAGED_STRUCTURED
+    }
+
+    /**
+     * Currently selected artifact management style
+     */
+    public String artifactManagement;
+
+    /**
      * Let Jenkins manage the S3 uploaded artifacts
      */
     public boolean managedArtifacts;
@@ -62,17 +77,34 @@ public final class Entry implements Describable<Entry> {
 
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String storageClass, String selectedRegion,
-                 boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten) {
+                 boolean noUploadOnFailure, boolean uploadFromSlave, String artifactManagement,
+                 boolean managedArtifacts, boolean useServerSideEncryption, boolean flatten) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.storageClass = storageClass;
         this.selectedRegion = selectedRegion;
         this.noUploadOnFailure = noUploadOnFailure;
         this.uploadFromSlave = uploadFromSlave;
-        this.managedArtifacts = managedArtifacts;
+        this.artifactManagement = artifactManagement;
         this.useServerSideEncryption = useServerSideEncryption;
-        this.flatten = flatten;
+    }
+
+    public boolean isManaged() {
+        return isManaged(artifactManagement);
+    }
+
+    public static boolean isManaged(final String management) {
+        return ( managedArtifactsEnum.MANAGED_FLATTENED.name().equals(management) ||
+                managedArtifactsEnum.MANAGED_STRUCTURED.name().equals(management) );
+    }
+
+    public boolean isStructured() {
+        return isStructured(artifactManagement);
+    }
+
+    public static boolean isStructured(final String management) {
+        return ( managedArtifactsEnum.UNMANAGED_STRUCTURED.name().equals(management) ||
+                managedArtifactsEnum.MANAGED_STRUCTURED.name().equals(management) );
     }
 
     public Descriptor<Entry> getDescriptor() {
@@ -105,6 +137,13 @@ public final class Entry implements Describable<Entry> {
             return model;
         }
 
+        public ListBoxModel doFillArtifactManagementItems() {
+            ListBoxModel model = new ListBoxModel();
+            for (managedArtifactsEnum a : managedArtifactsEnum.values()) {
+                model.add(a.name(), a.name());
+            }
+            return model;
+        }
     };
 
 }

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -170,10 +170,10 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
                 List<FingerprintRecord> records = Lists.newArrayList();
                 
                 for (FilePath src : paths) {
-                    log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.managedArtifacts + " , server encryption "+entry.useServerSideEncryption);
-                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.flatten));
+                    log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.artifactManagement + " , server encryption "+entry.useServerSideEncryption);
+                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.artifactManagement, entry.useServerSideEncryption));
                 }
-                if (entry.managedArtifacts) {
+                if (entry.isManaged()) {
                     artifacts.addAll(records);
     
                     for (FingerprintRecord r : records) {

--- a/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
+++ b/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
@@ -228,7 +228,7 @@ public class S3CopyArtifact extends Builder {
         
         try {
             targetDir.mkdirs();
-            List<FingerprintRecord> records = profile.downloadAll(src, action.getArtifacts(), expandedFilter, targetDir, isFlatten(), console);
+            List<FingerprintRecord> records = profile.downloadAll(src, action.getArtifacts(), expandedFilter, targetDir, console);
 
             Map<String, String> fingerprints = Maps.newHashMap();
             for(FingerprintRecord record : records) {

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -131,25 +131,13 @@ public class S3Profile {
     }
 
     public FingerprintRecord upload(AbstractBuild<?,?> build, final BuildListener listener, String bucketName, FilePath filePath, int searchPathLength, List<MetadataPair> userMetadata,
-            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts,boolean useServerSideEncryption, boolean flatten) throws IOException, InterruptedException {
+            String storageClass, String selregion, boolean uploadFromSlave, String artifactManagement, boolean useServerSideEncryption) throws IOException, InterruptedException {
         if (filePath.isDirectory()) {
             throw new IOException(filePath + " is a directory");
         }
 
-        String fileName = null;
-        if (flatten) {
-            fileName = filePath.getName();
-        } else {
-            String relativeFileName = filePath.getRemote();
-            fileName = relativeFileName.substring(searchPathLength);
-        }
-
-        Destination dest = new Destination(bucketName, fileName);
-        boolean produced = false;
-        if (managedArtifacts) {
-            dest = Destination.newFromBuild(build, bucketName, filePath.getName());
-            produced = build.getTimeInMillis() <= filePath.lastModified()+2000;
-        }
+        Destination dest = new Destination(build.getParent().getName(), build.getNumber(), bucketName, filePath, searchPathLength, artifactManagement);
+        boolean produced = Entry.isManaged(artifactManagement) && (build.getTimeInMillis() <= filePath.lastModified() + 2000);
 
         try {
             S3UploadCallable callable = new S3UploadCallable(produced, getClient(), dest, userMetadata, storageClass, selregion,useServerSideEncryption);
@@ -164,11 +152,8 @@ public class S3Profile {
     }
 
     public List<String> list(Run build, String bucket, String expandedFilter) {
-        AmazonS3Client s3client = getClient();        
-
-        String buildName = build.getDisplayName();
-        int buildID = build.getNumber();
-        Destination dest = new Destination(bucket, "jobs/" + buildName + "/" + buildID + "/" + name);
+        AmazonS3Client s3client = getClient();
+        Destination dest = new Destination(build.getParent().getName(), build.getNumber(), bucket, name);
 
         ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
         .withBucketName(dest.bucketName)
@@ -191,7 +176,7 @@ public class S3Profile {
       /**
        * Download all artifacts from a given build
        */
-      public List<FingerprintRecord> downloadAll(Run build, List<FingerprintRecord> artifacts, String expandedFilter, FilePath targetDir, boolean flatten, PrintStream console) {
+      public List<FingerprintRecord> downloadAll(Run build, List<FingerprintRecord> artifacts, String expandedFilter, FilePath targetDir, PrintStream console) {
 
           FilenameSelector selector = new FilenameSelector();
           selector.setName(expandedFilter);
@@ -200,7 +185,7 @@ public class S3Profile {
           for(FingerprintRecord record : artifacts) {
               S3Artifact artifact = record.artifact;
               if (selector.isSelected(new File("/"), artifact.getName(), null)) {
-                  Destination dest = Destination.newFromRun(build, artifact);
+                  Destination dest = new Destination(build.getParent().getName(), build.getNumber(), artifact.getBucket(), artifact.getName());
                   FilePath target = new FilePath(targetDir, artifact.getName());
                   try {
                       fingerprints.add(target.act(new S3DownloadCallable(getClient(), dest, console)));
@@ -217,10 +202,10 @@ public class S3Profile {
       /**
        * Delete some artifacts of a given run
        * @param build
-       * @param artifact
+       * @param record
        */
       public void delete(Run build, FingerprintRecord record) {
-          Destination dest = Destination.newFromRun(build, record.artifact);
+          Destination dest = new Destination(build.getParent().getName(), build.getNumber(), record.artifact.getBucket(), record.artifact.getName());
           DeleteObjectRequest req = new DeleteObjectRequest(dest.bucketName, dest.objectName);
           getClient().deleteObject(req);
       }
@@ -235,13 +220,13 @@ public class S3Profile {
        * access S3.
        */
       public String getDownloadURL(Run build, FingerprintRecord record) {
-          Destination dest = Destination.newFromRun(build, record.artifact);
+          Destination dest = new Destination(build.getParent().getName(), build.getNumber(), record.artifact.getBucket(), record.artifact.getName());
           GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(dest.bucketName, dest.objectName);
           request.setExpiration(new Date(System.currentTimeMillis() + this.signedUrlExpirySeconds*1000));
           ResponseHeaderOverrides headers = new ResponseHeaderOverrides();
           // let the browser use the last part of the name, not the full path
           // when saving.
-          String fileName = (new File(dest.objectName)).getName().trim(); 
+          String fileName = (new File(dest.objectName)).getName().trim();
           headers.setContentDisposition("attachment; filename=\"" + fileName + "\"");
           request.setResponseHeaders(headers);
           URL url = getClient().generatePresignedUrl(request);

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -32,7 +32,8 @@ public class S3DownloadCallable extends AbstractS3Callable implements FileCallab
         GetObjectRequest req = new GetObjectRequest(dest.bucketName, dest.objectName);
         ObjectMetadata md = getClient().getObject(req, file);
 
-        return new FingerprintRecord(true, dest.bucketName, file.getName(), md.getETag());
+        return new FingerprintRecord(true, dest.userBucketName, dest.fileName, md.getETag());
+
     }
 
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -108,7 +108,7 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
             final PutObjectRequest request = new PutObjectRequest(dest.bucketName, dest.objectName, localFile)
                 .withMetadata(buildMetadata(file));
             final PutObjectResult result = getClient().putObject(request);
-            return new FingerprintRecord(produced, dest.bucketName, file.getName(), result.getETag());
+            return new FingerprintRecord(produced, dest.userBucketName, dest.fileName, result.getETag());
         } finally {
             if (os != null) {
                 os.close();

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -18,13 +18,10 @@
         <f:entry field="uploadFromSlave" title="Publish from Slave">
 		    <f:checkbox />
         </f:entry>
-        <f:entry field="managedArtifacts" title="Manage artifacts">
-		    <f:checkbox />
+        <f:entry title="Manage artifacts" field="artifactManagement">
+		    <f:select />
         </f:entry>
         <f:entry field="useServerSideEncryption" title="Server side encryption">
-		    <f:checkbox />
-        </f:entry>
-        <f:entry field="flatten" title="Flatten directories">
 		    <f:checkbox />
         </f:entry>
 

--- a/src/main/resources/hudson/plugins/s3/Entry/help-artifactManagement.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-artifactManagement.html
@@ -1,0 +1,24 @@
+<div>
+    This lets Jenkins manage the artifacts, exactly like it does when the artifacts are published to the master.
+    There are four options:
+    <ul>
+        <li><B>Unmanaged-flattened</B> stores the artifacts in the selected bucket,
+            discarding the directory structure of the artifacts in the source project.</li>
+        <li><B>Unmanaged-structured</B> stores the artifacts in the selected bucket
+            while maintaining the directory structure.</li>
+        <li><B>Managed-flattened</B> stores the artifacts in "jobs/[job]/[build-number]/" in the
+            selected bucket, discarding the directory structure.</li>
+        <li><B>Managed-structured</B> stores the artifacts in "jobs/[job]/[build-number]/" in the selected bucket
+            while maintaining the directory structure.</li>
+    </ul>
+
+    When using one of the managed options, the following features are enabled:
+    <ul>
+        <li>artifacts are finger printed and linked to the build</li>
+        <li>artifacts can be downloaded directly from the build page in the
+            S3 Artifact section</li>
+        <li>artifacts are automatically deleted when the build is deleted</li>
+        <li>the <em>S3 Copy Artifact</em> build step can be used to download artifacts from S3
+            automatically, helping build complex pipelines</li>
+    </ul>
+</div>


### PR DESCRIPTION
This is take 2 with a much cleaner commit history and a smaller change footprint.

**What & why**
This mod allows Jenkins-managed artifacts to preserve the original directory structure. Currently, the "Manage artifacts” option ignores the state of “Flatten directories”. The result is that Jenkins-managed artifacts are automatically flattened, whether desired or not.

**How**
The "Manage artifacts" and "Flatten" checkboxes have been replaced with a dropdown that offers a consistent set of options:

1. *Unmanaged-structured*. Artifacts are not managed by Jenkins and the directory structure of the source project is preserved. Equivalent to “Managed”=Unchecked & “Flattened”=Unchecked.

2. *Unmanaged-flattened*. Artifacts are not managed by Jenkins and live in a single directory in the bucket. Equivalent to “Managed”=Unchecked & “Flattened”=Checked.

3. *Managed-flattened*. Artifacts are managed by Jenkins and are flattened. Equivalent to “Managed”=Checked. (The state of “Flattened” does not matter.)

4. *Managed-structured*. Artifacts are managed and the directory structure is preserved. There is no equivalent in the existing plugin, but conceptually it would be “Managed”=Checked & “Flattened”=Unchecked.

![s3 plugin screenshot](https://cloud.githubusercontent.com/assets/1879625/5880128/b9675778-a303-11e4-887f-79767e78ffbd.png)
