### PR TITLE
Fix dependencies for running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.526</version>
+        <version>1.598</version>
     </parent>
 
     <artifactId>s3</artifactId>
@@ -48,37 +48,19 @@
             <version>1.9.6</version>
         </dependency>
         <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-            <version>3.2.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>copyartifact</artifactId>
             <version>1.21</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jffi</artifactId>
-            <version>1.2.7</version>
-            <scope>provided</scope>
-            <classifier>native</classifier>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jnr</groupId>
-            <artifactId>jffi</artifactId>
-            <version>1.2.7</version>
-            <scope>provided</scope>
+            <version>2.8</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.598</version>
+        <version>1.580.3</version>
     </parent>
 
     <artifactId>s3</artifactId>

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -13,6 +13,7 @@ import java.io.PrintStream;
 
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.jenkinsci.remoting.RoleChecker;
 
 public class S3DownloadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> 
 {
@@ -35,4 +36,8 @@ public class S3DownloadCallable extends AbstractS3Callable implements FileCallab
         return new FingerprintRecord(true, dest.bucketName, file.getName(), md.getETag());
     }
 
+    @Override
+    public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+        // TODO: fixme
+    }
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -24,6 +24,7 @@ import com.amazonaws.services.s3.internal.Mimetypes;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
+import org.jenkinsci.remoting.RoleChecker;
 
 public class S3UploadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> {
     private static final long serialVersionUID = 1L;
@@ -122,5 +123,10 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     private void setRegion() {
         Region region = RegionUtils.getRegion(Regions.fromName(selregion).getName());
         getClient().setRegion(region);
+    }
+
+    @Override
+    public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+        // TODO:
     }
 }

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -3,12 +3,19 @@ package hudson.plugins.s3;
 
 import com.gargoylesoftware.htmlunit.WebAssert;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class S3Test extends HudsonTestCase {
+public class S3Test {
 
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
     public void testConfig() throws Exception {
-        HtmlPage page = new WebClient().goTo("configure");
+
+        HtmlPage page = j.createWebClient().goTo("configure");
         WebAssert.assertTextPresent(page, "S3 profiles");
     }
 }

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -14,7 +14,6 @@ public class S3Test {
 
     @Test
     public void testConfig() throws Exception {
-
         HtmlPage page = j.createWebClient().goTo("configure");
         WebAssert.assertTextPresent(page, "S3 profiles");
     }


### PR DESCRIPTION
Fixing dependencies and removing old ones which don't appear to be useful.

This diff updates dependencies -- removes a few that don't appear to be useful and makes `mvn test` work locally.

