### PR TITLE
Reformat Source Code using IntelliJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -13,28 +14,28 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/S3+Plugin</url>
 
     <developers>
-        <developer> 
-            <id>dougm</id> 
-            <name>Doug MacEachern</name> 
+        <developer>
+            <id>dougm</id>
+            <name>Doug MacEachern</name>
         </developer>
-        <developer> 
-            <id>d6y</id> 
-            <name>Richard Dallaway</name> 
+        <developer>
+            <id>d6y</id>
+            <name>Richard Dallaway</name>
         </developer>
-        <developer> 
-            <id>longlho</id> 
-            <name>Long Ho</name> 
+        <developer>
+            <id>longlho</id>
+            <name>Long Ho</name>
         </developer>
-        <developer> 
-            <id>mikewatt</id> 
-            <name>Michael Watt</name> 
+        <developer>
+            <id>mikewatt</id>
+            <name>Michael Watt</name>
         </developer>
-        <developer> 
-            <id>dmbeer</id> 
+        <developer>
+            <id>dmbeer</id>
             <name>David Beer</name>
         </developer>
-        <developer> 
-            <id>mattias</id> 
+        <developer>
+            <id>mattias</id>
             <name>Mattias Appelgren</name>
         </developer>
     </developers>

--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -9,55 +9,50 @@ import java.io.Serializable;
 /**
  * Provides a way to construct a destination bucket name and object name based
  * on the bucket name provided by the user.
- * 
+ * <p/>
  * The convention implemented here is that a / in a bucket name is used to
  * construct a structure in the object name.  That is, a put of file.txt to bucket name
  * of "mybucket/v1" will cause the object "v1/file.txt" to be created in the mybucket.
- * 
  */
 public class Destination implements Serializable {
-  private static final long serialVersionUID = 1L;
-  public final String bucketName; 
-  public final String objectName; 
-  
-  public Destination(final String userBucketName, final String fileName) {
-    
-    if (userBucketName == null || fileName == null) 
-      throw new IllegalArgumentException("Not defined for null parameters: "+userBucketName+","+fileName);
-    
-    final String[] bucketNameArray = userBucketName.split("/", 2);
-    
-    bucketName = bucketNameArray[0];
-    
-    if (bucketNameArray.length > 1) {
-        objectName = bucketNameArray[1] + "/" + fileName;
-    } else {
-        objectName = fileName;
+    private static final long serialVersionUID = 1L;
+    public final String bucketName;
+    public final String objectName;
+
+    public Destination(final String userBucketName, final String fileName) {
+
+        if (userBucketName == null || fileName == null)
+            throw new IllegalArgumentException("Not defined for null parameters: " + userBucketName + "," + fileName);
+
+        final String[] bucketNameArray = userBucketName.split("/", 2);
+
+        bucketName = bucketNameArray[0];
+
+        if (bucketNameArray.length > 1) {
+            objectName = bucketNameArray[1] + "/" + fileName;
+        } else {
+            objectName = fileName;
+        }
     }
-  }
 
-@Override
- public String toString() {
-   return "Destination [bucketName="+bucketName+", objectName="+objectName+"]";
- }
-  
+    public static Destination newFromRun(Run run, String bucketName, String fileName) {
+        String projectName = run.getParent().getName();
+        int buildID = run.getNumber();
+        return new Destination(bucketName, "jobs/" + projectName + "/" + buildID + "/" + fileName);
+    }
 
-  public static Destination newFromRun(Run run, String bucketName, String fileName)
-  {
-    String projectName = run.getParent().getName();
-    int buildID = run.getNumber();
-    return new Destination(bucketName, "jobs/" + projectName + "/" + buildID + "/" + fileName);
-  }
+    public static Destination newFromRun(Run run, S3Artifact artifact) {
+        return newFromRun(run, artifact.getBucket(), artifact.getName());
+    }
 
-  public static Destination newFromRun(Run run, S3Artifact artifact) 
-  {
-    return newFromRun(run, artifact.getBucket(), artifact.getName());
-  }
-    
-  public static Destination newFromBuild(AbstractBuild<?, ?> build, String bucketName, String fileName)
-  {
-    String projectName = build.getParent().getName();
-    int buildID =build.getNumber();
-    return new Destination(bucketName, "jobs/" + projectName + "/" + buildID + "/" + fileName);
-  }
+    public static Destination newFromBuild(AbstractBuild<?, ?> build, String bucketName, String fileName) {
+        String projectName = build.getParent().getName();
+        int buildID = build.getNumber();
+        return new Destination(bucketName, "jobs/" + projectName + "/" + buildID + "/" + fileName);
+    }
+
+    @Override
+    public String toString() {
+        return "Destination [bucketName=" + bucketName + ", objectName=" + objectName + "]";
+    }
 }

--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -10,6 +10,16 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public final class Entry implements Describable<Entry> {
 
     /**
+     * options for x-amz-storage-class can be STANDARD or REDUCED_REDUNDANCY
+     */
+    public static final String[] storageClasses = {"STANDARD", "REDUCED_REDUNDANCY"};
+    /**
+     * Regions Values
+     */
+    public static final Regions[] regions = Regions.values();
+    @Extension
+    public final static DescriptorImpl DESCRIPOR = new DescriptorImpl();
+    /**
      * Destination bucket for the copy. Can contain macros.
      */
     public String bucket;
@@ -19,42 +29,29 @@ public final class Entry implements Describable<Entry> {
      */
     public String sourceFile;
     /**
-     * options for x-amz-storage-class can be STANDARD or REDUCED_REDUNDANCY
-     */
-    public static final String[] storageClasses = {"STANDARD", "REDUCED_REDUNDANCY"};
-    /**
      * what x-amz-storage-class is currently set
      */
     public String storageClass;
     /**
-     * Regions Values
-     */
-    public static final Regions[] regions = Regions.values();
-    /**
      * Stores the Region Value
      */
     public String selectedRegion;
-    
     /**
      * Do not publish the artifacts when build fails
      */
     public boolean noUploadOnFailure;
-
     /**
      * Upload either from the slave or the master
      */
     public boolean uploadFromSlave;
-
     /**
      * Let Jenkins manage the S3 uploaded artifacts
      */
     public boolean managedArtifacts;
-    
     /**
      * Use S3 server side encryption when uploading the artifacts
      */
     public boolean useServerSideEncryption;
-
     /**
      * Flatten directories
      */
@@ -79,10 +76,7 @@ public final class Entry implements Describable<Entry> {
         return DESCRIPOR;
     }
 
-    @Extension
-    public final static DescriptorImpl DESCRIPOR = new DescriptorImpl();
-
-    public static class DescriptorImpl extends  Descriptor<Entry> {
+    public static class DescriptorImpl extends Descriptor<Entry> {
 
         @Override
         public String getDisplayName() {
@@ -105,6 +99,6 @@ public final class Entry implements Describable<Entry> {
             return model;
         }
 
-    };
+    }
 
 }

--- a/src/main/java/hudson/plugins/s3/FingerprintRecord.java
+++ b/src/main/java/hudson/plugins/s3/FingerprintRecord.java
@@ -3,40 +3,39 @@ package hudson.plugins.s3;
 import hudson.model.AbstractBuild;
 import hudson.model.Fingerprint;
 import hudson.model.FingerprintMap;
+import jenkins.model.Jenkins;
 
 import java.io.IOException;
 import java.io.Serializable;
 
-import jenkins.model.Jenkins;
-
 public class FingerprintRecord implements Serializable {
-  private static final long serialVersionUID = 1L;
-  final boolean produced;
-  final String md5sum;
-  final S3Artifact artifact;
+    private static final long serialVersionUID = 1L;
+    final boolean produced;
+    final String md5sum;
+    final S3Artifact artifact;
 
 
-  public FingerprintRecord(boolean produced, String bucket, String name, String md5sum) {
-      this.produced = produced;
-      this.artifact = new S3Artifact(bucket, name);
-      this.md5sum = md5sum;
-  }
+    public FingerprintRecord(boolean produced, String bucket, String name, String md5sum) {
+        this.produced = produced;
+        this.artifact = new S3Artifact(bucket, name);
+        this.md5sum = md5sum;
+    }
 
-  Fingerprint addRecord(AbstractBuild<?,?> build) throws IOException {
-      FingerprintMap map = Jenkins.getInstance().getFingerprintMap();
-      return map.getOrCreate(produced?build:null, artifact.getName(), md5sum);
-  }
+    Fingerprint addRecord(AbstractBuild<?, ?> build) throws IOException {
+        FingerprintMap map = Jenkins.getInstance().getFingerprintMap();
+        return map.getOrCreate(produced ? build : null, artifact.getName(), md5sum);
+    }
 
-  public String getName() {
-    return artifact.getName();
-  }
+    public String getName() {
+        return artifact.getName();
+    }
 
-  public String getBucket() {
-    return artifact.getBucket();
-  }
+    public String getBucket() {
+        return artifact.getBucket();
+    }
 
-  public String getFingerprint() {
-    return md5sum;
-  }
+    public String getFingerprint() {
+        return md5sum;
+    }
 
 }

--- a/src/main/java/hudson/plugins/s3/MetadataPair.java
+++ b/src/main/java/hudson/plugins/s3/MetadataPair.java
@@ -7,12 +7,13 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 public final class MetadataPair implements Describable<MetadataPair> {
 
+    @Extension
+    public final static DescriptorImpl DESCRIPOR = new DescriptorImpl();
     /**
      * The key of the user metadata pair to tag an upload with.
      * Can contain macros.
      */
     public String key;
-
     /**
      * The key of the user metadata pair to tag an upload with.
      * Can contain macros.
@@ -29,14 +30,11 @@ public final class MetadataPair implements Describable<MetadataPair> {
         return DESCRIPOR;
     }
 
-    @Extension
-    public final static DescriptorImpl DESCRIPOR = new DescriptorImpl();
-
     public static class DescriptorImpl extends Descriptor<MetadataPair> {
 
         @Override
         public String getDisplayName() {
             return "Metadata";
         }
-    };
+    }
 }

--- a/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
+++ b/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
@@ -1,80 +1,78 @@
 package hudson.plugins.s3;
 
-import java.io.IOException;
-import java.util.List;
-
-import javax.servlet.ServletException;
-
+import hudson.model.AbstractBuild;
+import hudson.model.Run;
+import hudson.model.RunAction;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import hudson.model.RunAction;
-import hudson.model.AbstractBuild;
-import hudson.model.Run;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
 
 public class S3ArtifactsAction implements RunAction {
-  private final AbstractBuild build;
-  private final String profile;
-  private final List<FingerprintRecord> artifacts;
+    private final AbstractBuild build;
+    private final String profile;
+    private final List<FingerprintRecord> artifacts;
 
-  public S3ArtifactsAction(AbstractBuild<?,?> build, S3Profile profile, List<FingerprintRecord> artifacts) {
-      this.build = build;
-      this.profile = profile.getName();
-      this.artifacts = artifacts;
-      onLoad();   // make compact
-  }
+    public S3ArtifactsAction(AbstractBuild<?, ?> build, S3Profile profile, List<FingerprintRecord> artifacts) {
+        this.build = build;
+        this.profile = profile.getName();
+        this.artifacts = artifacts;
+        onLoad();   // make compact
+    }
 
-  public AbstractBuild<?,?> getBuild() {
-      return build;
-  }
+    public AbstractBuild<?, ?> getBuild() {
+        return build;
+    }
 
-  public String getIconFileName() {
-    return "fingerprint.png";
-  }
+    public String getIconFileName() {
+        return "fingerprint.png";
+    }
 
-  public String getDisplayName() {
-    return "S3 Artifacts";
-  }
+    public String getDisplayName() {
+        return "S3 Artifacts";
+    }
 
-  public String getUrlName() {
-    return "s3";
-  }
+    public String getUrlName() {
+        return "s3";
+    }
 
-  public void onLoad() {
-  }
+    public void onLoad() {
+    }
 
-  public void onAttached(Run r) {
-  }
+    public void onAttached(Run r) {
+    }
 
-  public void onBuildComplete() {
-  }
+    public void onBuildComplete() {
+    }
 
-  public String getProfile() {
-    return profile;
-  }
+    public String getProfile() {
+        return profile;
+    }
 
-  public List<FingerprintRecord> getArtifacts() {
-    return artifacts;
-  }
+    public List<FingerprintRecord> getArtifacts() {
+        return artifacts;
+    }
 
-  public void doDownload(final StaplerRequest request, final StaplerResponse response) throws IOException, ServletException {
+    public void doDownload(final StaplerRequest request, final StaplerResponse response) throws IOException, ServletException {
 
-      String restOfPath = request.getRestOfPath();
-      if (restOfPath == null) {
-          return;
-      }
+        String restOfPath = request.getRestOfPath();
+        if (restOfPath == null) {
+            return;
+        }
 
-      // skip the leading /
-      String artifact = restOfPath.substring(1);
-      for (FingerprintRecord record : getArtifacts()) {
-          if (record.artifact.getName().equals(artifact)) {
-              S3Profile s3 = S3BucketPublisher.getProfile(profile);
-              String url = s3.getDownloadURL(build, record);
-              response.sendRedirect2(url);
-              return;
-          }
-      }
-      response.sendError(404, "This artifact is not available");
-  }
+        // skip the leading /
+        String artifact = restOfPath.substring(1);
+        for (FingerprintRecord record : getArtifacts()) {
+            if (record.artifact.getName().equals(artifact)) {
+                S3Profile s3 = S3BucketPublisher.getProfile(profile);
+                String url = s3.getDownloadURL(build, record);
+                response.sendRedirect2(url);
+                return;
+            }
+        }
+        response.sendError(404, "This artifact is not available");
+    }
 
 }

--- a/src/main/java/hudson/plugins/s3/S3ArtifactsProjectAction.java
+++ b/src/main/java/hudson/plugins/s3/S3ArtifactsProjectAction.java
@@ -1,10 +1,10 @@
 package hudson.plugins.s3;
 
-import java.util.List;
-
-import hudson.model.Action;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
 import hudson.model.Run;
+
+import java.util.List;
 
 public class S3ArtifactsProjectAction implements Action {
 
@@ -24,7 +24,7 @@ public class S3ArtifactsProjectAction implements Action {
         if (latestSuccessfulBuild == null) {
             return null;
         }
-         List<S3ArtifactsAction> actions = latestSuccessfulBuild.getActions(S3ArtifactsAction.class);
+        List<S3ArtifactsAction> actions = latestSuccessfulBuild.getActions(S3ArtifactsAction.class);
         if (actions == null || actions.size() == 0) {
             return null;
         }

--- a/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
+++ b/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
@@ -24,7 +24,6 @@
 package hudson.plugins.s3;
 
 import com.google.common.collect.Maps;
-import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -32,7 +31,6 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.console.HyperlinkNote;
-import hudson.diagnosis.OldDataMonitor;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
 import hudson.maven.MavenModuleSet;
@@ -42,13 +40,12 @@ import hudson.model.AbstractProject;
 import hudson.model.Build;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
-import hudson.model.Descriptor.FormException;
 import hudson.model.EnvironmentContributingAction;
 import hudson.model.Fingerprint;
 import hudson.model.FingerprintMap;
 import hudson.model.Hudson;
-import hudson.model.Job;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.Project;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -66,45 +63,39 @@ import hudson.tasks.Builder;
 import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.util.DescribableList;
 import hudson.util.FormValidation;
-import hudson.util.Memoizer;
-import hudson.util.XStream2;
+import jenkins.model.Jenkins;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import jenkins.model.Jenkins;
-import net.sf.json.JSONObject;
-
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-
 /**
  * This is a S3 variant of the CopyArtifact plugin:
  * Build step to copy artifacts from another project.
+ *
  * @author Alan Harder
  */
 public class S3CopyArtifact extends Builder {
 
-    private String projectName;
     private final String filter, target;
-    private /*almost final*/ BuildSelector selector;
     private final Boolean flatten, optional;
+    private String projectName;
+    private /*almost final*/ BuildSelector selector;
 
     @DataBoundConstructor
     public S3CopyArtifact(String projectName, BuildSelector selector, String filter, String target,
-                        boolean flatten, boolean optional) {
+                          boolean flatten, boolean optional) {
         // Prevents both invalid values and access to artifacts of projects which this user cannot see.
         // If value is parameterized, it will be checked when build runs.
         if (projectName.indexOf('$') < 0 && new JobResolver(projectName).job == null)
@@ -142,7 +133,7 @@ public class S3CopyArtifact extends Builder {
     }
 
     @Override
-    public boolean perform(AbstractBuild<?,?> build, Launcher launcher, BuildListener listener)
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
             throws InterruptedException {
         PrintStream console = listener.getLogger();
         String expandedProject = projectName, expandedFilter = filter;
@@ -152,14 +143,14 @@ public class S3CopyArtifact extends Builder {
             expandedProject = env.expand(projectName);
             JobResolver job = new JobResolver(expandedProject);
             if (job.job != null && !expandedProject.equals(projectName)
-                // If projectName is parameterized, need to do permission check on source project.
-                // Would like to check if user who started build has permission, but unable to get
-                // Authentication object for arbitrary user.. instead, only allow use of parameters
-                // to select jobs which are accessible to all authenticated users.
-                && !job.job.getACL().hasPermission(
-                        new UsernamePasswordAuthenticationToken("authenticated", "",
-                                new GrantedAuthority[]{ SecurityRealm.AUTHENTICATED_AUTHORITY }),
-                        Item.READ)) {
+                    // If projectName is parameterized, need to do permission check on source project.
+                    // Would like to check if user who started build has permission, but unable to get
+                    // Authentication object for arbitrary user.. instead, only allow use of parameters
+                    // to select jobs which are accessible to all authenticated users.
+                    && !job.job.getACL().hasPermission(
+                    new UsernamePasswordAuthenticationToken("authenticated", "",
+                            new GrantedAuthority[]{SecurityRealm.AUTHENTICATED_AUTHORITY}),
+                    Item.READ)) {
                 job.job = null; // Disallow access
             }
             if (job.job == null) {
@@ -189,7 +180,7 @@ public class S3CopyArtifact extends Builder {
                 // Copy artifacts from the build (ArchiveArtifacts build step)
                 boolean ok = perform(src, build, expandedFilter, targetDir, baseTargetDir, console);
                 // Copy artifacts from all modules of this Maven build (automatic archiving)
-                for (Run r : ((MavenModuleSetBuild)src).getModuleLastBuilds().values())
+                for (Run r : ((MavenModuleSetBuild) src).getModuleLastBuilds().values())
                     ok |= perform(r, build, expandedFilter, targetDir, baseTargetDir, console);
                 return ok;
             } else if (src instanceof MatrixBuild) {
@@ -199,13 +190,12 @@ public class S3CopyArtifact extends Builder {
                 for (Run r : ((MatrixBuild) src).getExactRuns())
                     // Use subdir of targetDir with configuration name (like "jdk=java6u20")
                     ok |= perform(r, build, expandedFilter, targetDir.child(r.getParent().getName()),
-                                  baseTargetDir, console);
+                            baseTargetDir, console);
                 return ok;
             } else {
                 return perform(src, build, expandedFilter, targetDir, baseTargetDir, console);
             }
-        }
-        catch (IOException ex) {
+        } catch (IOException ex) {
             Util.displayIOException(ex, listener);
             ex.printStackTrace(listener.error(
                     Messages.CopyArtifact_FailedToCopy(expandedProject, expandedFilter)));
@@ -213,46 +203,46 @@ public class S3CopyArtifact extends Builder {
         }
     }
 
-    private boolean perform(Run src, AbstractBuild<?,?> dst, String expandedFilter, FilePath targetDir,
-            FilePath baseTargetDir, PrintStream console)
+    private boolean perform(Run src, AbstractBuild<?, ?> dst, String expandedFilter, FilePath targetDir,
+                            FilePath baseTargetDir, PrintStream console)
             throws IOException, InterruptedException {
 
         S3ArtifactsAction action = src.getAction(S3ArtifactsAction.class);
         if (action == null) {
-          console.println("Build " + src.getDisplayName() + "[" + src.number + "] doesn't have any S3 artifacts uploaded");
-          return false;
+            console.println("Build " + src.getDisplayName() + "[" + src.number + "] doesn't have any S3 artifacts uploaded");
+            return false;
         }
-      
-       
+
+
         S3Profile profile = S3BucketPublisher.getProfile(action.getProfile());
-        
+
         try {
             targetDir.mkdirs();
             List<FingerprintRecord> records = profile.downloadAll(src, action.getArtifacts(), expandedFilter, targetDir, isFlatten(), console);
 
             Map<String, String> fingerprints = Maps.newHashMap();
-            for(FingerprintRecord record : records) {
+            for (FingerprintRecord record : records) {
                 FingerprintMap map = Jenkins.getInstance().getFingerprintMap();
-                
+
                 Fingerprint f = map.getOrCreate(src, record.getName(), record.getFingerprint());
-                if (src!=null) {
-                    f.add((AbstractBuild)src);
+                if (src != null) {
+                    f.add((AbstractBuild) src);
                 }
                 f.add(dst);
                 fingerprints.put(record.getName(), record.getFingerprint());
             }
 
-            for (AbstractBuild r : new AbstractBuild[]{src instanceof AbstractBuild ? (AbstractBuild)src : null,dst}) {
+            for (AbstractBuild r : new AbstractBuild[]{src instanceof AbstractBuild ? (AbstractBuild) src : null, dst}) {
                 if (r == null)
                     continue;
 
                 FingerprintAction fa = r.getAction(FingerprintAction.class);
                 if (fa != null) fa.add(fingerprints);
-                else            r.getActions().add(new FingerprintAction(r, fingerprints));
+                else r.getActions().add(new FingerprintAction(r, fingerprints));
             }
 
-            console.println(MessageFormat.format("Copied {0} {0,choice,0#artifacts|1#artifact|1<artifacts} from \"{1}\" build number {2} stored in S3", fingerprints.size(), HyperlinkNote.encodeTo('/'+ src.getParent().getUrl(), src.getParent().getFullDisplayName()),
-                    HyperlinkNote.encodeTo('/'+src.getUrl(), Integer.toString(src.getNumber()))));
+            console.println(MessageFormat.format("Copied {0} {0,choice,0#artifacts|1#artifact|1<artifacts} from \"{1}\" build number {2} stored in S3", fingerprints.size(), HyperlinkNote.encodeTo('/' + src.getParent().getUrl(), src.getParent().getFullDisplayName()),
+                    HyperlinkNote.encodeTo('/' + src.getUrl(), Integer.toString(src.getNumber()))));
             // Fail build if 0 files copied unless copy is optional
             return fingerprints.size() > 0 || isOptional();
         } finally {
@@ -262,7 +252,7 @@ public class S3CopyArtifact extends Builder {
     // Find the job from the given name; usually just a Hudson.getItemByFullName lookup,
     // but this class encapsulates additional logic like filtering on parameters.
     private static class JobResolver {
-        Job<?,?> job;
+        Job<?, ?> job;
         BuildFilter filter = new BuildFilter();
 
         JobResolver(String projectName) {
@@ -272,7 +262,7 @@ public class S3CopyArtifact extends Builder {
                 // Check for parameterized job with filter (see help file)
                 int i = projectName.indexOf('/');
                 if (i > 0) {
-                    Job<?,?> candidate = hudson.getItemByFullName(projectName.substring(0, i), Job.class);
+                    Job<?, ?> candidate = hudson.getItemByFullName(projectName.substring(0, i), Job.class);
                     if (candidate != null) {
                         ParametersBuildFilter pFilter = new ParametersBuildFilter(projectName.substring(i + 1));
                         if (pFilter.isValid(candidate)) {
@@ -295,19 +285,18 @@ public class S3CopyArtifact extends Builder {
             FormValidation result;
             Item item = new JobResolver(value).job;
             if (item != null) {
-                
+
                 result = item instanceof MavenModuleSet
-                       ? FormValidation.warning(Messages.CopyArtifact_MavenProject())
-                       : (item instanceof MatrixProject
-                          ? FormValidation.warning(Messages.CopyArtifact_MatrixProject())
-                          : FormValidation.ok());
-            }
-            else if (value.indexOf('$') >= 0)
+                        ? FormValidation.warning(Messages.CopyArtifact_MavenProject())
+                        : (item instanceof MatrixProject
+                        ? FormValidation.warning(Messages.CopyArtifact_MatrixProject())
+                        : FormValidation.ok());
+            } else if (value.indexOf('$') >= 0)
                 result = FormValidation.warning(Messages.CopyArtifact_ParameterizedName());
             else
                 result = FormValidation.error(
-                    hudson.tasks.Messages.BuildTrigger_NoSuchProject(
-                        value, AbstractProject.findNearest(value).getName()));
+                        hudson.tasks.Messages.BuildTrigger_NoSuchProject(
+                                value, AbstractProject.findNearest(value).getName()));
             return result;
         }
 
@@ -319,7 +308,7 @@ public class S3CopyArtifact extends Builder {
             return "S3 Copy Artifact";
         }
 
-        public DescriptorExtensionList<BuildSelector,Descriptor<BuildSelector>> getBuildSelectors() {
+        public DescriptorExtensionList<BuildSelector, Descriptor<BuildSelector>> getBuildSelectors() {
             final DescriptorExtensionList<BuildSelector, Descriptor<BuildSelector>> list = DescriptorExtensionList.createDescriptorList(Jenkins.getInstance(), BuildSelector.class);
             // remove from list some of the CopyArchiver build selector that we can't deal with
             list.remove(WorkspaceSelector.DESCRIPTOR);
@@ -330,34 +319,35 @@ public class S3CopyArtifact extends Builder {
     // Listen for project renames and update property here if needed.
     @Extension
     public static final class ListenerImpl extends ItemListener {
-        @Override
-        public void onRenamed(Item item, String oldName, String newName) {
-            for (AbstractProject<?,?> project
-                    : Hudson.getInstance().getAllItems(AbstractProject.class)) {
-                for (S3CopyArtifact ca : getCopiers(project)) try {
-                    if (ca.getProjectName().equals(oldName))
-                        ca.projectName = newName;
-                    else if (ca.getProjectName().startsWith(oldName + '/'))
-                        // Support rename for "MatrixJobName/AxisName=value" type of name
-                        ca.projectName = newName + ca.projectName.substring(oldName.length());
-                    else continue;
-                    project.save();
-                } catch (IOException ex) {
-                    Logger.getLogger(ListenerImpl.class.getName()).log(Level.WARNING,
-                            "Failed to resave project " + project.getName()
-                            + " for project rename in S3 Copy Artifact build step ("
-                            + oldName + " =>" + newName + ")", ex);
-                }
-            }
+        private static List<S3CopyArtifact> getCopiers(AbstractProject project) {
+            DescribableList<Builder, Descriptor<Builder>> list =
+                    project instanceof Project ? ((Project<?, ?>) project).getBuildersList()
+                            : (project instanceof MatrixProject ?
+                            ((MatrixProject) project).getBuildersList() : null);
+            if (list == null) return Collections.emptyList();
+            return list.getAll(S3CopyArtifact.class);
         }
 
-        private static List<S3CopyArtifact> getCopiers(AbstractProject project) {
-            DescribableList<Builder,Descriptor<Builder>> list =
-                    project instanceof Project ? ((Project<?,?>)project).getBuildersList()
-                      : (project instanceof MatrixProject ?
-                          ((MatrixProject)project).getBuildersList() : null);
-            if (list == null) return Collections.emptyList();
-            return (List<S3CopyArtifact>)list.getAll(S3CopyArtifact.class);
+        @Override
+        public void onRenamed(Item item, String oldName, String newName) {
+            for (AbstractProject<?, ?> project
+                    : Hudson.getInstance().getAllItems(AbstractProject.class)) {
+                for (S3CopyArtifact ca : getCopiers(project))
+                    try {
+                        if (ca.getProjectName().equals(oldName))
+                            ca.projectName = newName;
+                        else if (ca.getProjectName().startsWith(oldName + '/'))
+                            // Support rename for "MatrixJobName/AxisName=value" type of name
+                            ca.projectName = newName + ca.projectName.substring(oldName.length());
+                        else continue;
+                        project.save();
+                    } catch (IOException ex) {
+                        Logger.getLogger(ListenerImpl.class.getName()).log(Level.WARNING,
+                                "Failed to resave project " + project.getName()
+                                        + " for project rename in S3 Copy Artifact build step ("
+                                        + oldName + " =>" + newName + ")", ex);
+                    }
+            }
         }
     }
 
@@ -370,30 +360,38 @@ public class S3CopyArtifact extends Builder {
 
         @Override
         public void onStarted(Build r, TaskListener listener) {
-            if (((Build<?,?>)r).getProject().getBuildersList().get(S3CopyArtifact.class) != null)
+            if (((Build<?, ?>) r).getProject().getBuildersList().get(S3CopyArtifact.class) != null)
                 r.addAction(new EnvAction());
         }
     }
-    
+
     private static class EnvAction implements EnvironmentContributingAction {
         // Decided not to record this data in build.xml, so marked transient:
-        private transient Map<String,String> data = new HashMap<String,String>();
+        private transient Map<String, String> data = new HashMap<String, String>();
 
         private void add(String projectName, int buildNumber) {
-            if (data==null) return;
+            if (data == null) return;
             int i = projectName.indexOf('/'); // Omit any detail after a /
             if (i > 0) projectName = projectName.substring(0, i);
             data.put("COPYARTIFACT_BUILD_NUMBER_"
-                       + projectName.toUpperCase().replaceAll("[^A-Z]+", "_"), // Only use letters and _
-                     Integer.toString(buildNumber));
+                            + projectName.toUpperCase().replaceAll("[^A-Z]+", "_"), // Only use letters and _
+                    Integer.toString(buildNumber));
         }
 
-        public void buildEnvVars(AbstractBuild<?,?> build, EnvVars env) {
-            if (data!=null) env.putAll(data);
+        public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
+            if (data != null) env.putAll(data);
         }
 
-        public String getIconFileName() { return null; }
-        public String getDisplayName() { return null; }
-        public String getUrlName() { return null; }
+        public String getIconFileName() {
+            return null;
+        }
+
+        public String getDisplayName() {
+            return null;
+        }
+
+        public String getUrlName() {
+            return null;
+        }
     }
 }

--- a/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
@@ -1,25 +1,19 @@
 package hudson.plugins.s3.callable;
 
-import hudson.util.Secret;
+import com.amazonaws.services.s3.AmazonS3Client;
 
 import java.io.Serializable;
 
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
-
-public class AbstractS3Callable implements Serializable
-{
+public class AbstractS3Callable implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private transient AmazonS3Client client;
 
-    public AbstractS3Callable(AmazonS3Client client)
-    {
+    public AbstractS3Callable(AmazonS3Client client) {
         this.client = client;
     }
 
-    protected AmazonS3Client getClient() 
-    {
+    protected AmazonS3Client getClient() {
 //        if (client == null) {
 //            if (useRole) {
 //                client = new AmazonS3Client();

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -1,34 +1,29 @@
 package hudson.plugins.s3.callable;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import hudson.FilePath.FileCallable;
 import hudson.plugins.s3.Destination;
 import hudson.plugins.s3.FingerprintRecord;
 import hudson.remoting.VirtualChannel;
-import hudson.util.Secret;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 
-import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-
-public class S3DownloadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> 
-{
+public class S3DownloadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> {
     private static final long serialVersionUID = 1L;
     final private Destination dest;
     final transient private PrintStream log;
-    
-    public S3DownloadCallable(AmazonS3Client client, Destination dest, PrintStream console)
-    {
+
+    public S3DownloadCallable(AmazonS3Client client, Destination dest, PrintStream console) {
         super(client);
         this.dest = dest;
         this.log = console;
     }
 
-    public FingerprintRecord invoke(File file, VirtualChannel channel) throws IOException, InterruptedException 
-    {
+    public FingerprintRecord invoke(File file, VirtualChannel channel) throws IOException, InterruptedException {
         GetObjectRequest req = new GetObjectRequest(dest.bucketName, dest.objectName);
         ObjectMetadata md = getClient().getObject(req, file);
 

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -1,13 +1,19 @@
 package hudson.plugins.s3.callable;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.internal.Mimetypes;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
 import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.plugins.s3.Destination;
 import hudson.plugins.s3.FingerprintRecord;
 import hudson.plugins.s3.MetadataPair;
 import hudson.remoting.VirtualChannel;
-import hudson.util.Secret;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -16,14 +22,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.s3.internal.Mimetypes;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectResult;
 
 public class S3UploadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> {
     private static final long serialVersionUID = 1L;
@@ -35,7 +33,7 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     private final boolean useServerSideEncryption;
 
     public S3UploadCallable(boolean produced, AmazonS3Client client, Destination dest, List<MetadataPair> userMetadata, String storageClass,
-            String selregion, boolean useServerSideEncryption) {
+                            String selregion, boolean useServerSideEncryption) {
         super(client);
         this.dest = dest;
         this.storageClass = storageClass;
@@ -106,7 +104,7 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
             }
 
             final PutObjectRequest request = new PutObjectRequest(dest.bucketName, dest.objectName, localFile)
-                .withMetadata(buildMetadata(file));
+                    .withMetadata(buildMetadata(file));
             final PutObjectResult result = getClient().putObject(request);
             return new FingerprintRecord(produced, dest.bucketName, file.getName(), result.getETag());
         } finally {

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -1,31 +1,31 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
-        <f:entry title="Source" field="sourceFile">
-          <f:textbox/>
-        </f:entry>
-        <f:entry title="Destination bucket" field="bucket">
-          <f:textbox/>
-        </f:entry>
-        <f:entry title="Storage class" field="storageClass">
-          <f:select />
-        </f:entry>
-        <f:entry title="Bucket Region" field="selectedRegion">
-            <f:select/>
-        </f:entry>
-        <f:entry field="noUploadOnFailure" title="No upload on build failure">
-		    <f:checkbox />
-        </f:entry>
-        <f:entry field="uploadFromSlave" title="Publish from Slave">
-		    <f:checkbox />
-        </f:entry>
-        <f:entry field="managedArtifacts" title="Manage artifacts">
-		    <f:checkbox />
-        </f:entry>
-        <f:entry field="useServerSideEncryption" title="Server side encryption">
-		    <f:checkbox />
-        </f:entry>
-        <f:entry field="flatten" title="Flatten directories">
-		    <f:checkbox />
-        </f:entry>
+    <f:entry title="Source" field="sourceFile">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="Destination bucket" field="bucket">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="Storage class" field="storageClass">
+        <f:select/>
+    </f:entry>
+    <f:entry title="Bucket Region" field="selectedRegion">
+        <f:select/>
+    </f:entry>
+    <f:entry field="noUploadOnFailure" title="No upload on build failure">
+        <f:checkbox/>
+    </f:entry>
+    <f:entry field="uploadFromSlave" title="Publish from Slave">
+        <f:checkbox/>
+    </f:entry>
+    <f:entry field="managedArtifacts" title="Manage artifacts">
+        <f:checkbox/>
+    </f:entry>
+    <f:entry field="useServerSideEncryption" title="Server side encryption">
+        <f:checkbox/>
+    </f:entry>
+    <f:entry field="flatten" title="Flatten directories">
+        <f:checkbox/>
+    </f:entry>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-bucket.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-bucket.html
@@ -1,2 +1,3 @@
 <div>Destination bucket. It will be created if doesn't exist. Environment variable can be used, for example
-my-artifact-bucket/${JOB_NAME}-${BUILD_NUMBER}</div>
+    my-artifact-bucket/${JOB_NAME}-${BUILD_NUMBER}
+</div>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-flatten.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-flatten.html
@@ -1,6 +1,6 @@
 <div>
-When enabled, Jenkins will ignore the directory structure of the artifacts in
-the source project and copy all matching artifacts directly into the specified
-bucket. By default the artifacts are copied in the same directory structure as
-the source project.
+    When enabled, Jenkins will ignore the directory structure of the artifacts in
+    the source project and copy all matching artifacts directly into the specified
+    bucket. By default the artifacts are copied in the same directory structure as
+    the source project.
 </div>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-managedArtifacts.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-managedArtifacts.html
@@ -1,17 +1,19 @@
 <div>
-When enabled, this lets Jenkins fully manage the artifacts, exactly like it does when the artifacts
-are published to the master.
-<br>
-In this case, the artifacts are stored in the "jobs/[job]/[build-number]/" path in the selected
-bucket and prefix path. 
+    When enabled, this lets Jenkins fully manage the artifacts, exactly like it does when the artifacts
+    are published to the master.
+    <br>
+    In this case, the artifacts are stored in the "jobs/[job]/[build-number]/" path in the selected
+    bucket and prefix path.
 
-This means the following features are enabled:
-<ul>
-<li>artifacts are finger printed and linked to the build</li>
-<li>artifacts can be downloaded directly from the build page in the 
-S3 Artifact section</li>
-<li>artifacts are automatically deleted when the build is deleted</li>
-<li>the <em>S3 Copy Artifact</em> build step can be used to download artifacts from S3
-automatically, helping build complex pipelines</li>
-</ul>
+    This means the following features are enabled:
+    <ul>
+        <li>artifacts are finger printed and linked to the build</li>
+        <li>artifacts can be downloaded directly from the build page in the
+            S3 Artifact section
+        </li>
+        <li>artifacts are automatically deleted when the build is deleted</li>
+        <li>the <em>S3 Copy Artifact</em> build step can be used to download artifacts from S3
+            automatically, helping build complex pipelines
+        </li>
+    </ul>
 </div>

--- a/src/main/resources/hudson/plugins/s3/MetadataPair/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/MetadataPair/config.jelly
@@ -1,10 +1,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
-        <f:entry title="Metadata key" field="key">
-          <f:textbox />
-        </f:entry>
-        <f:entry title="Metadata value" field="value">
-          <f:textbox />
-        </f:entry>
+    <f:entry title="Metadata key" field="key">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="Metadata value" field="value">
+        <f:textbox/>
+    </f:entry>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3ArtifactsAction/index.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3ArtifactsAction/index.jelly
@@ -1,30 +1,32 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <l:layout>
-    <st:include it="${it.build}" page="sidepanel.jelly" />
-    <l:main-panel>
-      <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
-        S3 Artifacts
-      </h1>
-      <table class="fingerprint-in-build sortable bigtable">
-        <tr>
-          <th initialSortDir="down">Artifacts</th>
-          <th/>
-        </tr>
-        <j:forEach var="e" items="${it.artifacts}">
-          <tr>
-            <td>
-							<a href="download/${e.name}">${h.escape(e.name)}</a>
-            </td>
-            <td>
-              <a href="${rootURL}/fingerprint/${e.fingerprint}/">
-                <img src="${imagesURL}/16x16/fingerprint.png" alt="" height="16" width="16"/> ${%more details}
-              </a>
-            </td>
-          </tr>
-        </j:forEach>
-      </table>
-    </l:main-panel>
-  </l:layout>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
+        >
+    <l:layout>
+        <st:include it="${it.build}" page="sidepanel.jelly"/>
+        <l:main-panel>
+            <h1>
+                <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+                S3 Artifacts
+            </h1>
+            <table class="fingerprint-in-build sortable bigtable">
+                <tr>
+                    <th initialSortDir="down">Artifacts</th>
+                    <th/>
+                </tr>
+                <j:forEach var="e" items="${it.artifacts}">
+                    <tr>
+                        <td>
+                            <a href="download/${e.name}">${h.escape(e.name)}</a>
+                        </td>
+                        <td>
+                            <a href="${rootURL}/fingerprint/${e.fingerprint}/">
+                                <img src="${imagesURL}/16x16/fingerprint.png" alt="" height="16" width="16"/>
+                                ${%more details}
+                            </a>
+                        </td>
+                    </tr>
+                </j:forEach>
+            </table>
+        </l:main-panel>
+    </l:layout>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3ArtifactsProjectAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3ArtifactsProjectAction/jobMain.jelly
@@ -1,21 +1,23 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core"
+         xmlns:t="/lib/hudson">
 
-  <j:set var="latestDeployedArtifacts" value="${it.latestDeployedArtifacts}"/>
-  <j:if test="${latestDeployedArtifacts != null}">
-      <table style="margin-top: 1em; margin-left:1em;">
-        <t:summary icon="package.gif">
-            ${%Last Successful Deployed Artifacts}
-            <ul>
-               <j:set var="lastSuccessfulNumber" value="${it.lastSuccessfulNumber}"/>
-               <j:forEach var="artifact" items="${latestDeployedArtifacts.artifacts}" >
-                   <li>
-                       <a href="${lastSuccessfulNumber}/s3/download/${artifact.name}">${h.escape(artifact.name)}</a>
-                       <br />
-                   </li>
-               </j:forEach>
-            </ul>
-        </t:summary>
-      </table>
-  </j:if>
+    <j:set var="latestDeployedArtifacts" value="${it.latestDeployedArtifacts}"/>
+    <j:if test="${latestDeployedArtifacts != null}">
+        <table style="margin-top: 1em; margin-left:1em;">
+            <t:summary icon="package.gif">
+                ${%Last Successful Deployed Artifacts}
+                <ul>
+                    <j:set var="lastSuccessfulNumber" value="${it.lastSuccessfulNumber}"/>
+                    <j:forEach var="artifact" items="${latestDeployedArtifacts.artifacts}">
+                        <li>
+                            <a href="${lastSuccessfulNumber}/s3/download/${artifact.name}">${h.escape(artifact.name)}
+                            </a>
+                            <br/>
+                        </li>
+                    </j:forEach>
+                </ul>
+            </t:summary>
+        </table>
+    </j:if>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -1,31 +1,32 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
 
-  <j:set var="helpURL" value="/plugin/s3" />
+    <j:set var="helpURL" value="/plugin/s3"/>
     <f:entry title="S3 profile" field="profileName">
-      <f:select/>
+        <f:select/>
     </f:entry>
 
-  <f:entry title="Files to upload">
-    <f:repeatableProperty field="entries">
-      <f:entry title="">
-          <div align="right">
-            <f:repeatableDeleteButton />
-          </div>
-      </f:entry>
-    </f:repeatableProperty>
-  </f:entry>
+    <f:entry title="Files to upload">
+        <f:repeatableProperty field="entries">
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton/>
+                </div>
+            </f:entry>
+        </f:repeatableProperty>
+    </f:entry>
 
-  <f:entry title="Metadata tags">
-    <f:repeatableProperty field="userMetadata">
-        <f:entry title="">
-          <div align="right">
-            <f:repeatableDeleteButton />
-          </div>
-        </f:entry>
-    </f:repeatableProperty>
-  </f:entry>
+    <f:entry title="Metadata tags">
+        <f:repeatableProperty field="userMetadata">
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton/>
+                </div>
+            </f:entry>
+        </f:repeatableProperty>
+    </f:entry>
 
-  <f:entry field="dontWaitForConcurrentBuildCompletion" title="">
-    <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3" />
-  </f:entry>
+    <f:entry field="dontWaitForConcurrentBuildCompletion" title="">
+        <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -1,57 +1,59 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <!-- nothing to configure -->
-  <f:section title="Amazon S3 profiles">
-    <f:entry title="S3 profiles" description="Profiles for publishing to S3 buckets">
-      <f:repeatable var="profile" items="${descriptor.profiles}">
-        <table width="100%">
-          <f:entry title="Profile name" help="/plugin/s3/help-profile.html">
-            <f:textbox name="s3.name" value="${profile.name}"/>
-          </f:entry>
-          <f:entry title="Max upload retries">
-            <f:number name="s3.maxUploadRetries" value="${profile.maxUploadRetries}"/>
-          </f:entry>
-          <f:entry title="Retry wait time (seconds)" >
-            <f:number name="s3.retryWaitTime" value="${profile.retryWaitTime}"/>
-          </f:entry>
-          <f:optionalBlock title="Use IAM Role" help="/plugin/s3/help-role.html"
-                           checked="${profile.useRole}"
-                           inline="true" negative="true" name="s3.useRole">
-            <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
-              <f:textbox name="s3.accessKey" value="${profile.accessKey}"
-                         checkMethod="post"
-                         checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)"
-              />
-            </f:entry>
-            <f:entry title="Secret key" help="/plugin/s3/help-secretkey.html">
-              <input class="setting-input" name="s3.secretKey"
-                     type="password" value="${profile.secretKey}"
-                     onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()"
-               />
-            </f:entry>
-          </f:optionalBlock>
-          <f:entry title="Proxy Host" help="/plugin/s3/help-proxyHost.html">
-            <input class="setting-input" name="s3.proxyHost"
-                   value="${profile.proxyHost}"
-            />
-          </f:entry>
-          <f:entry title="Proxy Port" help="/plugin/s3/help-proxyPort.html">
-            <input class="setting-input" name="s3.proxyPort"
-                   value="${profile.proxyPort}"
-            />
-          </f:entry>
-          <f:entry title="">
-            <div align="right">
-              <f:repeatableDeleteButton />
-            </div>
-          </f:entry>
-          <f:advanced>
-            <f:entry title="Download URL expiry (seconds)" help="/plugin/s3/help-signedUrlExpirySeconds.html">
-              <f:number clazz="positive-number" name="s3.signedUrlExpirySeconds"
-                        value="${profile.signedUrlExpirySeconds}" default="60" />
-            </f:entry>
-          </f:advanced>
-        </table>
-      </f:repeatable>
-    </f:entry>
-  </f:section>
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form">
+    <!-- nothing to configure -->
+    <f:section title="Amazon S3 profiles">
+        <f:entry title="S3 profiles" description="Profiles for publishing to S3 buckets">
+            <f:repeatable var="profile" items="${descriptor.profiles}">
+                <table width="100%">
+                    <f:entry title="Profile name" help="/plugin/s3/help-profile.html">
+                        <f:textbox name="s3.name" value="${profile.name}"/>
+                    </f:entry>
+                    <f:entry title="Max upload retries">
+                        <f:number name="s3.maxUploadRetries" value="${profile.maxUploadRetries}"/>
+                    </f:entry>
+                    <f:entry title="Retry wait time (seconds)">
+                        <f:number name="s3.retryWaitTime" value="${profile.retryWaitTime}"/>
+                    </f:entry>
+                    <f:optionalBlock title="Use IAM Role" help="/plugin/s3/help-role.html"
+                                     checked="${profile.useRole}"
+                                     inline="true" negative="true" name="s3.useRole">
+                        <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
+                            <f:textbox name="s3.accessKey" value="${profile.accessKey}"
+                                       checkMethod="post"
+                                       checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)"
+                                    />
+                        </f:entry>
+                        <f:entry title="Secret key" help="/plugin/s3/help-secretkey.html">
+                            <input class="setting-input" name="s3.secretKey"
+                                   type="password" value="${profile.secretKey}"
+                                   onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()"
+                                    />
+                        </f:entry>
+                    </f:optionalBlock>
+                    <f:entry title="Proxy Host" help="/plugin/s3/help-proxyHost.html">
+                        <input class="setting-input" name="s3.proxyHost"
+                               value="${profile.proxyHost}"
+                                />
+                    </f:entry>
+                    <f:entry title="Proxy Port" help="/plugin/s3/help-proxyPort.html">
+                        <input class="setting-input" name="s3.proxyPort"
+                               value="${profile.proxyPort}"
+                                />
+                    </f:entry>
+                    <f:entry title="">
+                        <div align="right">
+                            <f:repeatableDeleteButton/>
+                        </div>
+                    </f:entry>
+                    <f:advanced>
+                        <f:entry title="Download URL expiry (seconds)"
+                                 help="/plugin/s3/help-signedUrlExpirySeconds.html">
+                            <f:number clazz="positive-number" name="s3.signedUrlExpirySeconds"
+                                      value="${profile.signedUrlExpirySeconds}" default="60"/>
+                        </f:entry>
+                    </f:advanced>
+                </table>
+            </f:repeatable>
+        </f:entry>
+    </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-dontWaitForConcurrentBuildCompletion.html
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-dontWaitForConcurrentBuildCompletion.html
@@ -1,5 +1,6 @@
 <div>
-    When disabled, only publish to S3 after completion of concurrent builds to prevent overriding published artifact. You
+    When disabled, only publish to S3 after completion of concurrent builds to prevent overriding published artifact.
+    You
     can enable this to publish to S3 at the end of each concurrent build. Published artifact should then have a
     different name for each build to prevent unnecessary uploads.
 </div>

--- a/src/main/resources/hudson/plugins/s3/S3CopyArtifact/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3CopyArtifact/config.jelly
@@ -1,21 +1,25 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:ca="/hudson/plugins/copyartifact">
-  <f:entry title="Project name" field="projectName">
-    <f:editableComboBox items="${app.topLevelItemNames}" clazz="setting-input"/>
-  </f:entry>
-  <ca:selectorList currentSelector="${instance.buildSelector}"
-      name="selector" title="Which build"/>
-  <f:entry title="Artifacts to copy" field="filter">
-    <f:textbox/>
-  </f:entry>
-  <f:entry title="Target directory" field="target">
-    <f:textbox/>
-  </f:entry>
-  <f:entry help="/plugin/copyartifact/help-flatten-optional.html">
-    <f:checkbox field="flatten"/>
-    <label class="attach-previous">Flatten directories</label>
-    <st:nbsp/> <st:nbsp/> <st:nbsp/> <st:nbsp/> <st:nbsp/>
-    <f:checkbox field="optional"/>
-    <label class="attach-previous">Optional</label>
-  </f:entry>
+    <f:entry title="Project name" field="projectName">
+        <f:editableComboBox items="${app.topLevelItemNames}" clazz="setting-input"/>
+    </f:entry>
+    <ca:selectorList currentSelector="${instance.buildSelector}"
+                     name="selector" title="Which build"/>
+    <f:entry title="Artifacts to copy" field="filter">
+        <f:textbox/>
+    </f:entry>
+    <f:entry title="Target directory" field="target">
+        <f:textbox/>
+    </f:entry>
+    <f:entry help="/plugin/copyartifact/help-flatten-optional.html">
+        <f:checkbox field="flatten"/>
+        <label class="attach-previous">Flatten directories</label>
+        <st:nbsp/>
+        <st:nbsp/>
+        <st:nbsp/>
+        <st:nbsp/>
+        <st:nbsp/>
+        <f:checkbox field="optional"/>
+        <label class="attach-previous">Optional</label>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/selectorList.jelly
+++ b/src/main/resources/hudson/plugins/s3/selectorList.jelly
@@ -23,45 +23,45 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
-  <st:documentation>
-    Generates a dropdown list with the available BuildSelectors.
-    <st:attribute name="currentSelector" use="required">
-      BuildSelector that is currently configured; form is populated showing this object.
-    </st:attribute>
-    <st:attribute name="name" use="required">
-      Name for the form element.
-    </st:attribute>
-    <st:attribute name="title" use="required">
-      Title for the form section.
-    </st:attribute>
-    <st:attribute name="description">
-      Optional description for form section.
-    </st:attribute>
-    <st:attribute name="descriptor">
-      Provide the descriptor that has getBuildSelectors(), if not already in ${descriptor}.
-    </st:attribute>
-    <st:attribute name="omit">
-      Optional name of a selector type to omit from the list.
-    </st:attribute>
-  </st:documentation>
-  <f:dropdownList name="${attrs.name}" title="${attrs.title}" description="${attrs.description}"
-                  help="/plugin/copyartifact/help-buildSelector.html">
-    <j:if test="${dropdownListMode=='generateEntries'}">
-      <d:invokeBody/>
-    </j:if>
-    <j:forEach var="bsDescriptor" items="${descriptor.buildSelectors.iterator()}" varStatus="loop">
-      <j:if test="${bsDescriptor.clazz.simpleName!=attrs.omit}">
-        <j:set var="selector"
-               value="${bsDescriptor==currentSelector.descriptor ? currentSelector : null}"/>
-        <f:dropdownListBlock title="${bsDescriptor.displayName}" value="${loop.index}"
-                             selected="${selector!=null}" staplerClass="${bsDescriptor.clazz.name}">
-          <j:scope>
-            <j:set var="descriptor" value="${bsDescriptor}" />
-            <j:set var="instance" value="${selector}" />
-            <st:include page="config.jelly" class="${bsDescriptor.clazz}" optional="${true}"/>
-          </j:scope>
-        </f:dropdownListBlock>
-      </j:if>
-    </j:forEach>
-  </f:dropdownList>
+    <st:documentation>
+        Generates a dropdown list with the available BuildSelectors.
+        <st:attribute name="currentSelector" use="required">
+            BuildSelector that is currently configured; form is populated showing this object.
+        </st:attribute>
+        <st:attribute name="name" use="required">
+            Name for the form element.
+        </st:attribute>
+        <st:attribute name="title" use="required">
+            Title for the form section.
+        </st:attribute>
+        <st:attribute name="description">
+            Optional description for form section.
+        </st:attribute>
+        <st:attribute name="descriptor">
+            Provide the descriptor that has getBuildSelectors(), if not already in ${descriptor}.
+        </st:attribute>
+        <st:attribute name="omit">
+            Optional name of a selector type to omit from the list.
+        </st:attribute>
+    </st:documentation>
+    <f:dropdownList name="${attrs.name}" title="${attrs.title}" description="${attrs.description}"
+                    help="/plugin/copyartifact/help-buildSelector.html">
+        <j:if test="${dropdownListMode=='generateEntries'}">
+            <d:invokeBody/>
+        </j:if>
+        <j:forEach var="bsDescriptor" items="${descriptor.buildSelectors.iterator()}" varStatus="loop">
+            <j:if test="${bsDescriptor.clazz.simpleName!=attrs.omit}">
+                <j:set var="selector"
+                       value="${bsDescriptor==currentSelector.descriptor ? currentSelector : null}"/>
+                <f:dropdownListBlock title="${bsDescriptor.displayName}" value="${loop.index}"
+                                     selected="${selector!=null}" staplerClass="${bsDescriptor.clazz.name}">
+                    <j:scope>
+                        <j:set var="descriptor" value="${bsDescriptor}"/>
+                        <j:set var="instance" value="${selector}"/>
+                        <st:include page="config.jelly" class="${bsDescriptor.clazz}" optional="${true}"/>
+                    </j:scope>
+                </f:dropdownListBlock>
+            </j:if>
+        </j:forEach>
+    </f:dropdownList>
 </j:jelly>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -2,5 +2,5 @@
   This view is used to render the plugin list page.
 -->
 <div>
-  This is a plugin to upload files to Amazon S3 buckets.
+    This is a plugin to upload files to Amazon S3 buckets.
 </div>

--- a/src/main/webapp/help-projectConfig.html
+++ b/src/main/webapp/help-projectConfig.html
@@ -1,8 +1,8 @@
 <div>
-  <p>
-    This HTML fragment will be injected into the configuration screen
-    when the user clicks 'help'. See global.jelly and config.jelly
-    for how the form decides which page to load.
-    You can have any HTML fragment here.
-  </p>
+    <p>
+        This HTML fragment will be injected into the configuration screen
+        when the user clicks 'help'. See global.jelly and config.jelly
+        for how the form decides which page to load.
+        You can have any HTML fragment here.
+    </p>
 </div>

--- a/src/main/webapp/help-signedUrlExpirySeconds.html
+++ b/src/main/webapp/help-signedUrlExpirySeconds.html
@@ -1,1 +1,4 @@
-<div>When a user downloads an S3 artifact, Jenkins generates a signed URL to let them download it directly from S3. This URL lets anybody who knows the URL download the URL until it expires. Short expiry times prevent people from sharing the URL as easily but mean that the server's clock has to be synced to make sure it generates valid URLs.</div>
+<div>When a user downloads an S3 artifact, Jenkins generates a signed URL to let them download it directly from S3. This
+    URL lets anybody who knows the URL download the URL until it expires. Short expiry times prevent people from sharing
+    the URL as easily but mean that the server's clock has to be synced to make sure it generates valid URLs.
+</div>

--- a/src/main/webapp/help.html
+++ b/src/main/webapp/help.html
@@ -1,3 +1,3 @@
 <div>Upload artifacts to Amazon S3.
-You need to define an S3 profile on the Jenkins global config page.
+    You need to define an S3 profile on the Jenkins global config page.
 </div>

--- a/src/test/java/hudson/plugins/s3/BucketnameTest.java
+++ b/src/test/java/hudson/plugins/s3/BucketnameTest.java
@@ -1,30 +1,30 @@
 package hudson.plugins.s3;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class BucketnameTest {
 
-  @Test
-  public void testAnythingAfterSlashInBucketNameIsPrependedToObjectName() {
+    @Test
+    public void testAnythingAfterSlashInBucketNameIsPrependedToObjectName() {
 
-    // Assertions based on the behaviour of toString is maybe fragile but I think 
-    // reasonably readable.
-    
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=test.txt]", 
-        new Destination("my-bucket-name", "test.txt").toString() );
-    
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=foo/test.txt]", 
-        new Destination("my-bucket-name/foo", "test.txt").toString() );
-    
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=foo/baz/test.txt]", 
-        new Destination("my-bucket-name/foo/baz", "test.txt").toString() );
+        // Assertions based on the behaviour of toString is maybe fragile but I think
+        // reasonably readable.
 
-    // Unclear if this is the desired behaviour or not:
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=/test.txt]", 
-        new Destination("my-bucket-name/", "test.txt").toString() );
-  
-  }
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=test.txt]",
+                new Destination("my-bucket-name", "test.txt").toString());
+
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=foo/test.txt]",
+                new Destination("my-bucket-name/foo", "test.txt").toString());
+
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=foo/baz/test.txt]",
+                new Destination("my-bucket-name/foo/baz", "test.txt").toString());
+
+        // Unclear if this is the desired behaviour or not:
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=/test.txt]",
+                new Destination("my-bucket-name/", "test.txt").toString());
+
+    }
 
 }


### PR DESCRIPTION
There is a lot of inconsistencies in the coding conventions in this project. We should stick with one established convention, most notably spacing, import ordering and removing unused imports.

This diff applies the default IntelliJ formatting conventions over all the source files.