### PR TITLE
[FIXED JENKINS-27284] Pass always the build

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -41,6 +41,11 @@ public final class Entry implements Describable<Entry> {
     public boolean noUploadOnFailure;
 
     /**
+     * Make the build sucessful even if there is a failure in the S3 plugin
+     */
+    public boolean passTheBuildUnderS3Failure;
+
+    /**
      * Upload either from the slave or the master
      */
     public boolean uploadFromSlave;
@@ -63,7 +68,7 @@ public final class Entry implements Describable<Entry> {
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten) {
+                 boolean useServerSideEncryption, boolean flatten, boolean passTheBuildUnderS3Failure) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.storageClass = storageClass;
@@ -73,6 +78,7 @@ public final class Entry implements Describable<Entry> {
         this.managedArtifacts = managedArtifacts;
         this.useServerSideEncryption = useServerSideEncryption;
         this.flatten = flatten;
+        this.passTheBuildUnderS3Failure = passTheBuildUnderS3Failure;
     }
 
     public Descriptor<Entry> getDescriptor() {

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -15,6 +15,9 @@
         <f:entry field="noUploadOnFailure" title="No upload on build failure">
 		    <f:checkbox />
         </f:entry>
+        <f:entry field="passTheBuildUnderS3Failure" title="Pass always on failure" help="${helpURL}/help-pass-always-on-failure.html">
+            <f:checkbox name="s3.entry.passTheBuildUnderS3Failure" checked="${e.passTheBuildUnderS3Failure}"/>
+        </f:entry>
         <f:entry field="uploadFromSlave" title="Publish from Slave">
 		    <f:checkbox />
         </f:entry>

--- a/src/main/webapp/help-pass-always-on-failure.html
+++ b/src/main/webapp/help-pass-always-on-failure.html
@@ -1,0 +1,3 @@
+<div>
+    Don't mark the build as UNSTABLE in case there is any issue in the upload file porcess
+</div>


### PR DESCRIPTION
This pull request add the functionality of not to make the build unstable under some minor stacktrace you might get when uploading your file to Amazon S3. For example:

```
00-00 00:37:28 Publish artifacts to S3 Bucket bucket=qa-xxxxx-artifacts, file=xxxxxxx.log region=us-east-1, upload from slave=false managed=true , server encryption false 
00-00 00:37:29 FATAL: Unable to load resource META-INF/services/org.apache.commons.logging.LogFactory 
00-00 00:37:29 java.lang.Error: Unable to load resource META-INF/services/org.apache.commons.logging.LogFactory 
00-00 00:37:29 at hudson.remoting.RemoteClassLoader.findResource(RemoteClassLoader.java:376) 
00-00 00:37:29 at java.lang.ClassLoader.getResource(Unknown Source) 
00-00 00:37:29 at java.net.URLClassLoader.getResourceAsStream(Unknown Source) 
00-00 00:37:29 at org.apache.commons.logging.LogFactory$3.run(LogFactory.java:1280) 
.....
```
