### PR TITLE
Fix windows path issue while wildcarding

### DIFF
--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -37,12 +37,12 @@ public class Destination implements Serializable {
     }
   }
 
-    private String cleanFilenameFromPlatformSpecificCharacters(String fileName) {
-        return fileName.replace("\\", "/");
-    }
+  private String cleanFilenameFromPlatformSpecificCharacters(String fileName) {
+      return fileName.replace("\\", "/");
+  }
 
-    @Override
- public String toString() {
+  @Override
+  public String toString() {
    return "Destination [bucketName="+bucketName+", objectName="+objectName+"]";
  }
   

--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -26,18 +26,18 @@ public class Destination implements Serializable {
       throw new IllegalArgumentException("Not defined for null parameters: "+userBucketName+","+fileName);
     
     final String[] bucketNameArray = userBucketName.split("/", 2);
-    final String platformAgnosticFileName = cleanFilenameFromPlatformSpecificCharacters(fileName);
+    final String s3CompatibleFileName = replaceWindowsBackslashes(fileName);
     
     bucketName = bucketNameArray[0];
     
     if (bucketNameArray.length > 1) {
-        objectName = bucketNameArray[1] + "/" + platformAgnosticFileName;
+        objectName = bucketNameArray[1] + "/" + s3CompatibleFileName;
     } else {
-        objectName = platformAgnosticFileName;
+        objectName = s3CompatibleFileName;
     }
   }
 
-  private String cleanFilenameFromPlatformSpecificCharacters(String fileName) {
+  private String replaceWindowsBackslashes(String fileName) {
       return fileName.replace("\\", "/");
   }
 

--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -26,17 +26,22 @@ public class Destination implements Serializable {
       throw new IllegalArgumentException("Not defined for null parameters: "+userBucketName+","+fileName);
     
     final String[] bucketNameArray = userBucketName.split("/", 2);
+    final String platformAgnosticFileName = cleanFilenameFromPlatformSpecificCharacters(fileName);
     
     bucketName = bucketNameArray[0];
     
     if (bucketNameArray.length > 1) {
-        objectName = bucketNameArray[1] + "/" + fileName;
+        objectName = bucketNameArray[1] + "/" + platformAgnosticFileName;
     } else {
-        objectName = fileName;
+        objectName = platformAgnosticFileName;
     }
   }
 
-@Override
+    private String cleanFilenameFromPlatformSpecificCharacters(String fileName) {
+        return fileName.replace("\\", "/");
+    }
+
+    @Override
  public String toString() {
    return "Destination [bucketName="+bucketName+", objectName="+objectName+"]";
  }

--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -43,8 +43,8 @@ public class Destination implements Serializable {
 
   @Override
   public String toString() {
-   return "Destination [bucketName="+bucketName+", objectName="+objectName+"]";
- }
+    return "Destination [bucketName="+bucketName+", objectName="+objectName+"]";
+  }
   
 
   public static Destination newFromRun(Run run, String bucketName, String fileName)

--- a/src/test/java/hudson/plugins/s3/BucketnameTest.java
+++ b/src/test/java/hudson/plugins/s3/BucketnameTest.java
@@ -27,4 +27,10 @@ public class BucketnameTest {
   
   }
 
+  @Test
+  public void testWindowsPathsConvertingToS3CompatiblePaths() {
+    assertEquals("Destination [bucketName=my-bucket, objectName=with-some/subfolder//path-from/windows.txt]",
+            new Destination("my-bucket/with-some/subfolder/", "path-from\\windows.txt").toString() );
+  }
+
 }


### PR DESCRIPTION
We had the S3 plugin configured with the source parameter as `trunk/build/resources/**/*` on Windows builders.

As windows uses a backslash (`\`) instead of normal slashes (`/`) S3 appended this to the filename. Meaning in the target folder, a file was created with a name `my-really\cool-file.yml` instead of converting `my-really` to a folder.

This pull request fixes that bug by converting backslashes to slashes before defining the Destination in S3