### PR TITLE
use the user bucketname entry that includes prefixes in fingerprint

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -190,7 +190,7 @@ public class S3Profile {
 
         while (true) {
             try {
-                S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
+                S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, bucketName, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
                 if (uploadFromSlave) {
                     return filePath.act(callable);
                 } else {

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 
 public class S3UploadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> {
     private static final long serialVersionUID = 1L;
+    private final String bucketName;
     private final Destination dest;
     private final String storageClass;
     private final List<MetadataPair> userMetadata;
@@ -33,9 +34,10 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     private final boolean produced;
     private final boolean useServerSideEncryption;
 
-    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
+    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, String bucketName, Destination dest, List<MetadataPair> userMetadata, String storageClass,
             String selregion, boolean useServerSideEncryption) {
         super(accessKey, secretKey, useRole);
+        this.bucketName = bucketName;
         this.dest = dest;
         this.storageClass = storageClass;
         this.userMetadata = userMetadata;
@@ -107,7 +109,7 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
             final PutObjectRequest request = new PutObjectRequest(dest.bucketName, dest.objectName, localFile)
                 .withMetadata(buildMetadata(file));
             final PutObjectResult result = getClient().putObject(request);
-            return new FingerprintRecord(produced, dest.bucketName, file.getName(), result.getETag());
+            return new FingerprintRecord(produced, bucketName, file.getName(), result.getETag());
         } finally {
             if (os != null) {
                 os.close();

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -34,6 +34,12 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     private final boolean produced;
     private final boolean useServerSideEncryption;
 
+    @Deprecated
+    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
+                            String selregion, boolean useServerSideEncryption) {
+        this(produced, accessKey, secretKey, useRole, dest.bucketName, dest, userMetadata, storageClass, selregion, useServerSideEncryption);
+    }
+
     public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, String bucketName, Destination dest, List<MetadataPair> userMetadata, String storageClass,
             String selregion, boolean useServerSideEncryption) {
         super(accessKey, secretKey, useRole);


### PR DESCRIPTION
cherry-picked from https://github.com/learningobjectsinc/s3-plugin/commit/a81561d8e663cd58b588bac24ff44c8dff3d18f9

see https://issues.jenkins-ci.org/browse/JENKINS-26297
@reviewbybees