### PR TITLE
Support remoting 2.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.526</version>
+        <version>1.587</version>
     </parent>
 
     <artifactId>s3</artifactId>

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -6,6 +6,10 @@ import hudson.plugins.s3.FingerprintRecord;
 import hudson.remoting.VirtualChannel;
 import hudson.util.Secret;
 
+import org.jenkinsci.remoting.RoleChecker;
+import org.jenkinsci.remoting.RoleSensitive;
+import jenkins.security.Roles;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -33,5 +37,10 @@ public class S3DownloadCallable extends AbstractS3Callable implements FileCallab
 
         return new FingerprintRecord(true, dest.bucketName, file.getName(), md.getETag());
     }
+    
+    @Override
+	public void checkRoles(RoleChecker checker) throws SecurityException {
+		checker.check((RoleSensitive) this, Roles.SLAVE);
+	}
 
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -23,6 +23,9 @@ import com.amazonaws.services.s3.internal.Mimetypes;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
+import jenkins.security.Roles;
+import org.jenkinsci.remoting.RoleChecker;
+import org.jenkinsci.remoting.RoleSensitive;
 
 public class S3UploadCallable extends AbstractS3Callable implements FileCallable<FingerprintRecord> {
     private static final long serialVersionUID = 1L;
@@ -137,4 +140,9 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
 
         getClient().setRegion(region);
     }
+    
+        @Override
+	public void checkRoles(RoleChecker checker) throws SecurityException {
+		checker.check((RoleSensitive) this, Roles.SLAVE);
+	}
 }


### PR DESCRIPTION
Jenkins 1.587 includes remoting 2.47, which has a new Roles ABI. It's not possible to build the S3 plugin against a newer Jenkins without some slight changes to add the new interface.