### PR TITLE
Add "Switch role" capability, fix proxy settings

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -298,7 +298,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
             if (name == null) {// name is not entered yet
                 return FormValidation.ok();
             }
-            S3Profile profile = new S3Profile(name, req.getParameter("accessKey"), req.getParameter("secretKey"), false, req.getParameter("maxUploadRetries"), req.getParameter("retryWaitTime"));
+            S3Profile profile = new S3Profile(name, req.getParameter("accessKey"), req.getParameter("secretKey"), false, req.getParameter("maxUploadRetries"), req.getParameter("retryWaitTime"), false, null);
 
             try {
                 profile.check();

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -1,11 +1,17 @@
 package hudson.plugins.s3;
 
-import com.amazonaws.regions.Regions;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
-import hudson.model.*;
+import hudson.model.Action;
+import hudson.model.BuildListener;
+import hudson.model.Describable;
+import hudson.model.Result;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Fingerprint;
+import hudson.model.Run;
 import hudson.model.listeners.RunListener;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -15,18 +21,9 @@ import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.util.CopyOnWriteList;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import org.apache.commons.lang.StringUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,6 +31,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import com.amazonaws.regions.Regions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 public final class S3BucketPublisher extends Recorder implements Describable<Publisher> {
     
@@ -298,7 +307,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
             if (name == null) {// name is not entered yet
                 return FormValidation.ok();
             }
-            S3Profile profile = new S3Profile(name, req.getParameter("accessKey"), req.getParameter("secretKey"), false, req.getParameter("maxUploadRetries"), req.getParameter("retryWaitTime"), false, null);
+            S3Profile profile = new S3Profile(name, req.getParameter("accessKey"), req.getParameter("secretKey"), false, req.getParameter("maxUploadRetries"), req.getParameter("retryWaitTime"), req.getParameter("stsRoleArn"));
 
             try {
                 profile.check();

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -298,7 +298,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
             if (name == null) {// name is not entered yet
                 return FormValidation.ok();
             }
-            S3Profile profile = new S3Profile(name, req.getParameter("accessKey"), req.getParameter("secretKey"), req.getParameter("proxyHost"), req.getParameter("proxyPort"), false, req.getParameter("maxUploadRetries"), req.getParameter("retryWaitTime"));
+            S3Profile profile = new S3Profile(name, req.getParameter("accessKey"), req.getParameter("secretKey"), false, req.getParameter("maxUploadRetries"), req.getParameter("retryWaitTime"));
 
             try {
                 profile.check();

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -1,5 +1,6 @@
 package hudson.plugins.s3;
 
+
 import hudson.FilePath;
 
 import java.io.File;
@@ -39,19 +40,22 @@ public class S3Profile {
     private transient volatile AmazonS3Client client = null;
     private boolean useRole;
     private int signedUrlExpirySeconds = 60;
+    private boolean useSts;
+    private String stsRoleArn;
 
     public S3Profile() {
     }
 
-    public S3Profile(String name, String accessKey, String secretKey, boolean useRole, String maxUploadRetries, String retryWaitTime) {
+    public S3Profile(String name, String accessKey, String secretKey, boolean useRole, String maxUploadRetries, String retryWaitTime, boolean useSts, String stsRoleArn) {
         /* The old hardcoded URL expiry was 4s, so: */
-        this(name, accessKey, secretKey, useRole, 4, maxUploadRetries, retryWaitTime);
+        this(name, accessKey, secretKey, useRole, 4, maxUploadRetries, retryWaitTime, useSts, stsRoleArn);
     }
 
     @DataBoundConstructor
-    public S3Profile(String name, String accessKey, String secretKey, boolean useRole, int signedUrlExpirySeconds, String maxUploadRetries, String retryWaitTime) {
+    public S3Profile(String name, String accessKey, String secretKey, boolean useRole, int signedUrlExpirySeconds, String maxUploadRetries, String retryWaitTime, boolean useSts, String stsRoleArn) {
         this.name = name;
         this.useRole = useRole;
+        this.useSts = useSts;
         try {
             this.maxUploadRetries = Integer.parseInt(maxUploadRetries);
         } catch(NumberFormatException nfe) {
@@ -69,6 +73,11 @@ public class S3Profile {
         } else {
             this.accessKey = accessKey;
             this.secretKey = Secret.fromString(secretKey);
+        }
+        if (useSts) {
+            this.stsRoleArn = stsRoleArn;
+        } else {
+            this.stsRoleArn = "";
         }
     }
 
@@ -116,9 +125,25 @@ public class S3Profile {
         return signedUrlExpirySeconds;
     }
 
+    public boolean isUseSts() {
+        return useSts;
+    }
+
+    public void setUseSts(boolean useSts) {
+        this.useSts = useSts;
+    }
+
+    public String getStsRoleArn() {
+        return stsRoleArn;
+    }
+
+    public void setStsRoleArn(String stsRoleArn) {
+        this.stsRoleArn = stsRoleArn;
+    }
+
     public AmazonS3Client getClient() {
         if (client == null) {
-            client = S3Utils.createClient(accessKey, secretKey, useRole);
+            client = S3Utils.createClient(accessKey, secretKey, useRole, useSts, stsRoleArn);
         }
         return client;
     }
@@ -151,7 +176,7 @@ public class S3Profile {
 
         while (true) {
             try {
-                S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, bucketName, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
+                S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, useSts, stsRoleArn, bucketName, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
                 if (uploadFromSlave) {
                     return filePath.act(callable);
                 } else {
@@ -207,7 +232,7 @@ public class S3Profile {
                   Destination dest = Destination.newFromRun(build, artifact);
                   FilePath target = new FilePath(targetDir, artifact.getName());
                   try {
-                      fingerprints.add(target.act(new S3DownloadCallable(accessKey, secretKey, useRole, dest, console)));
+                      fingerprints.add(target.act(new S3DownloadCallable(accessKey, secretKey, useRole, useSts, stsRoleArn, dest, console)));
                   } catch (IOException e) {
                       e.printStackTrace();
                   } catch (InterruptedException e) {

--- a/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
@@ -5,7 +5,6 @@ import hudson.util.Secret;
 
 import java.io.Serializable;
 
-import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.s3.AmazonS3Client;
 
 public class AbstractS3Callable implements Serializable
@@ -15,23 +14,21 @@ public class AbstractS3Callable implements Serializable
     private final String accessKey;
     private final Secret secretKey;
     private final boolean useRole;
-    private final boolean useSts;
     private final String stsRoleArn;
     private transient AmazonS3Client client;
 
-    public AbstractS3Callable(String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn) 
+    public AbstractS3Callable(String accessKey, Secret secretKey, boolean useRole, String stsRoleArn) 
     {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.useRole = useRole;
-        this.useSts = useSts;
         this.stsRoleArn = stsRoleArn;
     }
 
     protected AmazonS3Client getClient() 
     {
         if (client == null) {
-            client = S3Utils.createClient(accessKey, secretKey, useRole, useSts, stsRoleArn);
+            client = S3Utils.createClient(accessKey, secretKey, useRole, stsRoleArn);
         }
         return client;
     }

--- a/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
@@ -5,7 +5,7 @@ import hudson.util.Secret;
 
 import java.io.Serializable;
 
-import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.services.s3.AmazonS3Client;
 
 public class AbstractS3Callable implements Serializable
@@ -15,21 +15,24 @@ public class AbstractS3Callable implements Serializable
     private final String accessKey;
     private final Secret secretKey;
     private final boolean useRole;
+    private final boolean useSts;
+    private final String stsRoleArn;
     private transient AmazonS3Client client;
 
-    public AbstractS3Callable(String accessKey, Secret secretKey, boolean useRole) 
+    public AbstractS3Callable(String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn) 
     {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.useRole = useRole;
+        this.useSts = useSts;
+        this.stsRoleArn = stsRoleArn;
     }
 
     protected AmazonS3Client getClient() 
     {
         if (client == null) {
-            client = S3Utils.createClient(accessKey, secretKey, useRole);
+            client = S3Utils.createClient(accessKey, secretKey, useRole, useSts, stsRoleArn);
         }
         return client;
     }
-
 }

--- a/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/AbstractS3Callable.java
@@ -1,5 +1,6 @@
 package hudson.plugins.s3.callable;
 
+import hudson.plugins.s3.utils.S3Utils;
 import hudson.util.Secret;
 
 import java.io.Serializable;
@@ -26,11 +27,7 @@ public class AbstractS3Callable implements Serializable
     protected AmazonS3Client getClient() 
     {
         if (client == null) {
-            if (useRole) {
-                client = new AmazonS3Client();
-            } else {
-                client = new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey.getPlainText()));
-            }
+            client = S3Utils.createClient(accessKey, secretKey, useRole);
         }
         return client;
     }

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -19,9 +19,9 @@ public class S3DownloadCallable extends AbstractS3Callable implements FileCallab
     final private Destination dest;
     final transient private PrintStream log;
     
-    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn, Destination dest, PrintStream console) 
+    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, String stsRoleArn, Destination dest, PrintStream console) 
     {
-        super(accessKey, secretKey, useRole, useSts, stsRoleArn);
+        super(accessKey, secretKey, useRole, stsRoleArn);
         this.dest = dest;
         this.log = console;
     }

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -19,9 +19,9 @@ public class S3DownloadCallable extends AbstractS3Callable implements FileCallab
     final private Destination dest;
     final transient private PrintStream log;
     
-    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, PrintStream console) 
+    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn, Destination dest, PrintStream console) 
     {
-        super(accessKey, secretKey, useRole);
+        super(accessKey, secretKey, useRole, useSts, stsRoleArn);
         this.dest = dest;
         this.log = console;
     }

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -37,12 +37,12 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     @Deprecated
     public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
                             String selregion, boolean useServerSideEncryption) {
-        this(produced, accessKey, secretKey, useRole, dest.bucketName, dest, userMetadata, storageClass, selregion, useServerSideEncryption);
+        this(produced, accessKey, secretKey, useRole, false, null, dest.bucketName, dest, userMetadata, storageClass, selregion, useServerSideEncryption);
     }
 
-    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, String bucketName, Destination dest, List<MetadataPair> userMetadata, String storageClass,
+    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn, String bucketName, Destination dest, List<MetadataPair> userMetadata, String storageClass,
             String selregion, boolean useServerSideEncryption) {
-        super(accessKey, secretKey, useRole);
+        super(accessKey, secretKey, useRole, useSts, stsRoleArn);
         this.bucketName = bucketName;
         this.dest = dest;
         this.storageClass = storageClass;

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -37,12 +37,12 @@ public class S3UploadCallable extends AbstractS3Callable implements FileCallable
     @Deprecated
     public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, Destination dest, List<MetadataPair> userMetadata, String storageClass,
                             String selregion, boolean useServerSideEncryption) {
-        this(produced, accessKey, secretKey, useRole, false, null, dest.bucketName, dest, userMetadata, storageClass, selregion, useServerSideEncryption);
+        this(produced, accessKey, secretKey, useRole, null, dest.bucketName, dest, userMetadata, storageClass, selregion, useServerSideEncryption);
     }
 
-    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn, String bucketName, Destination dest, List<MetadataPair> userMetadata, String storageClass,
+    public S3UploadCallable(boolean produced, String accessKey, Secret secretKey, boolean useRole, String stsRoleArn, String bucketName, Destination dest, List<MetadataPair> userMetadata, String storageClass,
             String selregion, boolean useServerSideEncryption) {
-        super(accessKey, secretKey, useRole, useSts, stsRoleArn);
+        super(accessKey, secretKey, useRole, stsRoleArn);
         this.bucketName = bucketName;
         this.dest = dest;
         this.storageClass = storageClass;

--- a/src/main/java/hudson/plugins/s3/utils/S3Utils.java
+++ b/src/main/java/hudson/plugins/s3/utils/S3Utils.java
@@ -1,0 +1,55 @@
+package hudson.plugins.s3.utils;
+
+import hudson.ProxyConfiguration;
+import hudson.util.Secret;
+
+import java.util.regex.Pattern;
+
+import jenkins.model.Jenkins;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+public class S3Utils {
+
+    public static AmazonS3Client createClient(String accessKey, Secret secretKey, boolean useRole) {
+        AmazonS3Client client;
+        if (useRole) {
+            client = new AmazonS3Client(getClientConfiguration());
+        } else {
+            client = new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey.getPlainText()), getClientConfiguration());
+        }
+        return client;
+    }
+
+    private static ClientConfiguration getClientConfiguration() {
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+
+        ProxyConfiguration proxy = Jenkins.getInstance().proxy;
+        if (shouldUseProxy(proxy, "s3.amazonaws.com")) {
+            clientConfiguration.setProxyHost(proxy.name);
+            clientConfiguration.setProxyPort(proxy.port);
+            if (proxy.getUserName() != null) {
+                clientConfiguration.setProxyUsername(proxy.getUserName());
+                clientConfiguration.setProxyPassword(proxy.getPassword());
+            }
+        }
+        return clientConfiguration;
+    }
+
+    private static boolean shouldUseProxy(ProxyConfiguration proxy, String hostname) {
+        if (proxy == null) {
+            return false;
+        }
+        boolean shouldProxy = true;
+        for (Pattern p : proxy.getNoProxyHostPatterns()) {
+            if (p.matcher(hostname).matches()) {
+                shouldProxy = false;
+                break;
+            }
+        }
+
+        return shouldProxy;
+    }
+}

--- a/src/main/java/hudson/plugins/s3/utils/S3Utils.java
+++ b/src/main/java/hudson/plugins/s3/utils/S3Utils.java
@@ -17,7 +17,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 
 public class S3Utils {
 
-    public static AmazonS3Client createClient(String accessKey, Secret secretKey, boolean useRole, boolean useSts, String stsRoleArn) {
+    public static AmazonS3Client createClient(String accessKey, Secret secretKey, boolean useRole, String stsRoleArn) {
         AWSCredentialsProvider credentialsProvider;
         if (useRole) {
             credentialsProvider = new DefaultAWSCredentialsProviderChain();
@@ -25,7 +25,7 @@ public class S3Utils {
             BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey.getPlainText());
             credentialsProvider = new StaticCredentialsProvider(credentials);
         }
-        if (useSts) {
+        if (stsRoleArn != null && !stsRoleArn.isEmpty()) {
             credentialsProvider = new STSAssumeRoleSessionCredentialsProvider(credentialsProvider, stsRoleArn, "foo",
                     getClientConfiguration());
         }

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -19,7 +19,7 @@
             <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
               <f:textbox name="s3.accessKey" value="${profile.accessKey}"
                          checkMethod="post"
-                         checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)"
+                         checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)+'&amp;stsRoleArn='+encodeURIComponent(Form.findMatchingInput(this,'s3.stsRoleArn').value)"
               />
             </f:entry>
             <f:entry title="Secret key" help="/plugin/s3/help-secretkey.html">
@@ -29,18 +29,14 @@
                />
             </f:entry>
           </f:optionalBlock>
-          <f:optionalBlock title="Switch Role" help="/plugin/s3/help-sts.html"
-                           checked="${profile.useSts}"
-                           inline="true" name="s3.useSts">
-            <f:entry title="Role ARN" help="/plugin/s3/help-sts-role.html">
-              <f:textbox name="s3.stsRoleArn" value="${profile.stsRoleArn}"
-                         onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()" />
-            </f:entry>
-          </f:optionalBlock>
           <f:advanced>
             <f:entry title="Download URL expiry (seconds)" help="/plugin/s3/help-signedUrlExpirySeconds.html">
               <f:number clazz="positive-number" name="s3.signedUrlExpirySeconds"
                         value="${profile.signedUrlExpirySeconds}" default="60" />
+            </f:entry>
+            <f:entry title="Switch to role (ARN)" help="/plugin/s3/help-sts.html">
+              <f:textbox name="s3.stsRoleArn" value="${profile.stsRoleArn}"
+                         onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()" />
             </f:entry>
           </f:advanced>
 

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -29,16 +29,6 @@
                />
             </f:entry>
           </f:optionalBlock>
-          <f:entry title="Proxy Host" help="/plugin/s3/help-proxyHost.html">
-            <input class="setting-input" name="s3.proxyHost"
-                   value="${profile.proxyHost}"
-            />
-          </f:entry>
-          <f:entry title="Proxy Port" help="/plugin/s3/help-proxyPort.html">
-            <input class="setting-input" name="s3.proxyPort"
-                   value="${profile.proxyPort}"
-            />
-          </f:entry>
           <f:advanced>
             <f:entry title="Download URL expiry (seconds)" help="/plugin/s3/help-signedUrlExpirySeconds.html">
               <f:number clazz="positive-number" name="s3.signedUrlExpirySeconds"

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -29,6 +29,14 @@
                />
             </f:entry>
           </f:optionalBlock>
+          <f:optionalBlock title="Switch Role" help="/plugin/s3/help-sts.html"
+                           checked="${profile.useSts}"
+                           inline="true" name="s3.useSts">
+            <f:entry title="Role ARN" help="/plugin/s3/help-sts-role.html">
+              <f:textbox name="s3.stsRoleArn" value="${profile.stsRoleArn}"
+                         onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()" />
+            </f:entry>
+          </f:optionalBlock>
           <f:advanced>
             <f:entry title="Download URL expiry (seconds)" help="/plugin/s3/help-signedUrlExpirySeconds.html">
               <f:number clazz="positive-number" name="s3.signedUrlExpirySeconds"

--- a/src/main/webapp/help-sts-role.html
+++ b/src/main/webapp/help-sts-role.html
@@ -1,1 +1,0 @@
-<div>Full ARN of the IAM role to switch to.</div>

--- a/src/main/webapp/help-sts-role.html
+++ b/src/main/webapp/help-sts-role.html
@@ -1,0 +1,1 @@
+<div>Full ARN of the IAM role to switch to.</div>

--- a/src/main/webapp/help-sts.html
+++ b/src/main/webapp/help-sts.html
@@ -1,0 +1,1 @@
+<div>If ticked switch Role with STS.</div>

--- a/src/main/webapp/help-sts.html
+++ b/src/main/webapp/help-sts.html
@@ -1,1 +1,1 @@
-<div>If ticked switch Role with STS.</div>
+<div>Full ARN of the role to switch to. Leave empty to not switch role</div>


### PR DESCRIPTION
- add a "Switch role" option in advanced options (see [AWS blog](https://aws.amazon.com/blogs/aws/new-cross-account-access-in-the-aws-management-console/) for details about this feature)
- fix proxy settings :
  - remove unused proxy configuration fields (Jenkins proxy is used)
  - fix inconsistencies in AmazonS3Client creation (see factorized code in hudson.plugins.s3.utils.S3Utils)
