### PR TITLE
Add "noFilename" option: `Destination bucket` will be used as final key, ignoring the original filename

### DIFF
--- a/src/main/java/hudson/plugins/s3/Destination.java
+++ b/src/main/java/hudson/plugins/s3/Destination.java
@@ -22,14 +22,16 @@ public class Destination implements Serializable {
   
   public Destination(final String userBucketName, final String fileName) {
     
-    if (userBucketName == null || fileName == null) 
-      throw new IllegalArgumentException("Not defined for null parameters: "+userBucketName+","+fileName);
+    if (userBucketName == null)
+      throw new IllegalArgumentException("Not defined for null parameters: "+userBucketName);
     
     final String[] bucketNameArray = userBucketName.split("/", 2);
     
     bucketName = bucketNameArray[0];
-    
-    if (bucketNameArray.length > 1) {
+
+    if (fileName == null) {
+        objectName = bucketNameArray[1];
+    } else if (bucketNameArray.length > 1) {
         objectName = bucketNameArray[1] + "/" + fileName;
     } else {
         objectName = fileName;

--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -60,10 +60,15 @@ public final class Entry implements Describable<Entry> {
      */
     public boolean flatten;
 
+    /**
+     * Never use filename, use destination bucket as full key
+     */
+    public boolean noFilename;
+
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten) {
+                 boolean useServerSideEncryption, boolean flatten, boolean noFilename) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.storageClass = storageClass;
@@ -73,6 +78,7 @@ public final class Entry implements Describable<Entry> {
         this.managedArtifacts = managedArtifacts;
         this.useServerSideEncryption = useServerSideEncryption;
         this.flatten = flatten;
+        this.noFilename = noFilename;
     }
 
     public Descriptor<Entry> getDescriptor() {

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -179,7 +179,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
                 
                 for (FilePath src : paths) {
                     log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.managedArtifacts + " , server encryption "+entry.useServerSideEncryption);
-                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.flatten));
+                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.flatten, entry.noFilename));
                 }
                 if (entry.managedArtifacts) {
                     artifacts.addAll(records);

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -180,6 +180,8 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
                 for (FilePath src : paths) {
                     log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.managedArtifacts + " , server encryption "+entry.useServerSideEncryption);
                     records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.flatten, entry.noFilename));
+                    if (entry.noFilename)
+                        break;
                 }
                 if (entry.managedArtifacts) {
                     artifacts.addAll(records);

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -167,17 +167,19 @@ public class S3Profile {
     }
 
     public FingerprintRecord upload(AbstractBuild<?,?> build, final BuildListener listener, String bucketName, FilePath filePath, int searchPathLength, List<MetadataPair> userMetadata,
-            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts,boolean useServerSideEncryption, boolean flatten) throws IOException, InterruptedException {
+            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts,boolean useServerSideEncryption, boolean flatten, boolean noFilename) throws IOException, InterruptedException {
         if (filePath.isDirectory()) {
             throw new IOException(filePath + " is a directory");
         }
 
         String fileName = null;
-        if (flatten) {
-            fileName = filePath.getName();
-        } else {
-            String relativeFileName = filePath.getRemote();
-            fileName = relativeFileName.substring(searchPathLength);
+        if (!noFilename) {
+            if (flatten) {
+                fileName = filePath.getName();
+            } else {
+                String relativeFileName = filePath.getRemote();
+                fileName = relativeFileName.substring(searchPathLength);
+            }
         }
 
         Destination dest = new Destination(bucketName, fileName);
@@ -207,7 +209,7 @@ public class S3Profile {
     }
 
     public List<String> list(Run build, String bucket, String expandedFilter) {
-        AmazonS3Client s3client = getClient();        
+        AmazonS3Client s3client = getClient();
 
         String buildName = build.getDisplayName();
         int buildID = build.getNumber();
@@ -218,7 +220,7 @@ public class S3Profile {
         .withPrefix(dest.objectName);
 
         List<String> files = Lists.newArrayList();
-        
+
         ObjectListing objectListing;
         do {
           objectListing = s3client.listObjects(listObjectsRequest);
@@ -227,7 +229,7 @@ public class S3Profile {
             files.add(req.getKey());
           }
           listObjectsRequest.setMarker(objectListing.getNextMarker());
-        } while (objectListing.isTruncated());        
+        } while (objectListing.isTruncated());
         return files;
       }
 
@@ -238,7 +240,7 @@ public class S3Profile {
 
           FilenameSelector selector = new FilenameSelector();
           selector.setName(expandedFilter);
-          
+
           List<FingerprintRecord> fingerprints = Lists.newArrayList();
           for(FingerprintRecord record : artifacts) {
               S3Artifact artifact = record.artifact;
@@ -284,7 +286,7 @@ public class S3Profile {
           ResponseHeaderOverrides headers = new ResponseHeaderOverrides();
           // let the browser use the last part of the name, not the full path
           // when saving.
-          String fileName = (new File(dest.objectName)).getName().trim(); 
+          String fileName = (new File(dest.objectName)).getName().trim();
           headers.setContentDisposition("attachment; filename=\"" + fileName + "\"");
           request.setResponseHeaders(headers);
           URL url = getClient().generatePresignedUrl(request);

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -27,5 +27,8 @@
         <f:entry field="flatten" title="Flatten directories">
 		    <f:checkbox />
         </f:entry>
+        <f:entry field="noFilename" title="No filename">
+		    <f:checkbox />
+        </f:entry>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-noFilename.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-noFilename.html
@@ -1,0 +1,6 @@
+<div>
+    When enabled, Jenkins will ignore the source filename when uploading. So the
+    Destination bucket will be used as final key for the uploaded file.
+    Please note: only one source file must be selected (otherwise, only the first
+    file will be uploaded and others will be ignored)
+</div>


### PR DESCRIPTION
When enabled, Jenkins will ignore the source filename when uploading. So the Destination bucket will be used as final key for the uploaded file.
Please note: only one source file must be selected (otherwise, only the first file will be uploaded and others will be ignored)