### PR TITLE
Optional GZIP encoding

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -60,10 +60,16 @@ public final class Entry implements Describable<Entry> {
      */
     public boolean flatten;
 
+    /**
+    * use GZIP to compress files
+    */
+
+    public boolean gzipFiles;
+
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten) {
+                 boolean useServerSideEncryption, boolean flatten, boolean gzipFiles) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.storageClass = storageClass;
@@ -73,6 +79,7 @@ public final class Entry implements Describable<Entry> {
         this.managedArtifacts = managedArtifacts;
         this.useServerSideEncryption = useServerSideEncryption;
         this.flatten = flatten;
+        this.gzipFiles = gzipFiles;
     }
 
     public Descriptor<Entry> getDescriptor() {

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -179,7 +179,7 @@ public final class S3BucketPublisher extends Recorder implements Describable<Pub
                 
                 for (FilePath src : paths) {
                     log(listener.getLogger(), "bucket=" + bucket + ", file=" + src.getName() + " region=" + selRegion + ", upload from slave=" + entry.uploadFromSlave + " managed="+ entry.managedArtifacts + " , server encryption "+entry.useServerSideEncryption);
-                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.flatten));
+                    records.add(profile.upload(build, listener, bucket, src, searchPathLength, escapedUserMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.flatten, entry.gzipFiles));
                 }
                 if (entry.managedArtifacts) {
                     artifacts.addAll(records);

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -167,7 +167,7 @@ public class S3Profile {
     }
 
     public FingerprintRecord upload(AbstractBuild<?,?> build, final BuildListener listener, String bucketName, FilePath filePath, int searchPathLength, List<MetadataPair> userMetadata,
-            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts,boolean useServerSideEncryption, boolean flatten) throws IOException, InterruptedException {
+            String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts, boolean useServerSideEncryption, boolean flatten, boolean gzipFiles) throws IOException, InterruptedException {
         if (filePath.isDirectory()) {
             throw new IOException(filePath + " is a directory");
         }
@@ -190,7 +190,7 @@ public class S3Profile {
 
         while (true) {
             try {
-                S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, bucketName, dest, userMetadata, storageClass, selregion,useServerSideEncryption);
+                S3UploadCallable callable = new S3UploadCallable(produced, accessKey, secretKey, useRole, bucketName, dest, userMetadata, storageClass, selregion, useServerSideEncryption, gzipFiles);
                 if (uploadFromSlave) {
                     return filePath.act(callable);
                 } else {

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -27,5 +27,8 @@
         <f:entry field="flatten" title="Flatten directories">
 		    <f:checkbox />
         </f:entry>
+        <f:entry field="gzipFiles" title="GZIP files">
+            <f:checkbox />
+        </f:entry>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-gzipFiles.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-gzipFiles.html
@@ -1,0 +1,4 @@
+<div>
+When enabled, files will be compressed with GZIP and "Content-Encoding" header
+will be set to "gzip".
+</div>


### PR DESCRIPTION
Hi!

Here, at ZeroTurnaround, we use S3 to serve static websites. Since S3 doesn't support GZIP compression by default, only one option is to set "Content-Encoding: gzip" and gzip files before.

It could be done automatically in plugin as an option, and this pull request implements this logic. 

We use fork based on this change and it works fine (but of course additional testing on accepting would be good).

Also, this change will improve old behaviour as well because it will always use an InputStream of a file, and if file is a remote file then it will use a stream without putting it to the temporary file (we still need this temp file for gzipping because we don't want to get some OutOfMemory errors )

Thanks!