### PR TITLE
Metadata overrides per entry

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -7,6 +7,8 @@ import hudson.model.Descriptor;
 import hudson.util.ListBoxModel;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.List;
+
 public final class Entry implements Describable<Entry> {
 
     /**
@@ -66,10 +68,15 @@ public final class Entry implements Describable<Entry> {
 
     public boolean gzipFiles;
 
+    /**
+    * Metadata overrides
+    */
+    public List<MetadataPair> userMetadata;
+
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten, boolean gzipFiles) {
+                 boolean useServerSideEncryption, boolean flatten, boolean gzipFiles, List<MetadataPair> userMetadata) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.storageClass = storageClass;
@@ -80,6 +87,7 @@ public final class Entry implements Describable<Entry> {
         this.useServerSideEncryption = useServerSideEncryption;
         this.flatten = flatten;
         this.gzipFiles = gzipFiles;
+        this.userMetadata = userMetadata;
     }
 
     public Descriptor<Entry> getDescriptor() {

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -9,6 +9,7 @@ import java.io.PrintStream;
 import java.net.URL;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import jenkins.model.Jenkins;
@@ -166,7 +167,7 @@ public class S3Profile {
         getClient().listBuckets();
     }
 
-    public FingerprintRecord upload(AbstractBuild<?,?> build, final BuildListener listener, String bucketName, FilePath filePath, int searchPathLength, List<MetadataPair> userMetadata,
+    public FingerprintRecord upload(AbstractBuild<?,?> build, final BuildListener listener, String bucketName, FilePath filePath, int searchPathLength, Map<String, String> userMetadata,
             String storageClass, String selregion, boolean uploadFromSlave, boolean managedArtifacts, boolean useServerSideEncryption, boolean flatten, boolean gzipFiles) throws IOException, InterruptedException {
         if (filePath.isDirectory()) {
             throw new IOException(filePath + " is a directory");

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -31,4 +31,14 @@
             <f:checkbox />
         </f:entry>
 
+        <f:entry title="Metadata tags">
+            <f:repeatableProperty field="userMetadata">
+                <f:entry title="">
+                  <div align="right">
+                    <f:repeatableDeleteButton />
+                  </div>
+                </f:entry>
+            </f:repeatableProperty>
+        </f:entry>
+
 </j:jelly>


### PR DESCRIPTION
This pull request makes it possible to override metadata per entry. It's very useful when you want to specify metadata like "Cache-control: max-age=0" for a single file (aka "entry").

This is a non-breaking change so old configurations should work as well.