### PR TITLE
[FIXED JENKINS-32058] The selectorList is not in copyartifact anymore

### DIFF
--- a/src/main/resources/hudson/plugins/s3/S3CopyArtifact/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3CopyArtifact/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:ca="/hudson/plugins/copyartifact">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:ca="/hudson/plugins/s3">
   <f:entry title="Project name" field="projectName">
     <f:editableComboBox items="${app.topLevelItemNames}" clazz="setting-input"/>
   </f:entry>


### PR DESCRIPTION
Since 1.36 of copyartifact, the selectorList taglib is only in s3
plugin. The problem is that I cannot upgrade the dependency to
copyartifact:1.36 as it requires the core to be at 1.580.1 and will
change the callable implementation of s3 plugin.

This must be done but in a larger refactoring process.

@reviewbybees 