### PR TITLE
Add in the ability to set the contentType on files that are uploaded to S3

### DIFF
--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -75,6 +75,8 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
                 case "content-encoding":
                     metadata.setContentEncoding(entry.getValue());
                     break;
+                case "content-type":
+                    metadata.setContentType(entry.getValue());
                 default:
                     metadata.addUserMetadata(entry.getKey(), entry.getValue());
                     break;


### PR DESCRIPTION
Minor tweak to allow for setting the contentType on files that are uploaded to S3.

Example:  Uploading a JSON file and then being able to go to the s3 url to look at it without it automatically downloading the JSON file.