### PR TITLE
FIXED IE and Chrome download issue when file path is window style

### DIFF
--- a/src/main/java/hudson/plugins/s3/FingerprintRecord.java
+++ b/src/main/java/hudson/plugins/s3/FingerprintRecord.java
@@ -42,6 +42,11 @@ public class FingerprintRecord implements Serializable {
     public String getName() {
         return artifact.getName();
     }
+    @Exported
+    public String getLink() {
+        //Chrome and IE convert backslash in the URL into forward slashes, need escape with %5c
+        return artifact.getName().replace("\\","%5C");
+    }
 
     @Exported
     public String getFingerprint() {

--- a/src/main/java/hudson/plugins/s3/FingerprintRecord.java
+++ b/src/main/java/hudson/plugins/s3/FingerprintRecord.java
@@ -42,6 +42,7 @@ public class FingerprintRecord implements Serializable {
     public String getName() {
         return artifact.getName();
     }
+
     @Exported
     public String getLink() {
         //Chrome and IE convert backslash in the URL into forward slashes, need escape with %5c

--- a/src/main/resources/hudson/plugins/s3/S3ArtifactsAction/index.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3ArtifactsAction/index.jelly
@@ -15,7 +15,7 @@
         <j:forEach var="e" items="${it.artifacts}">
           <tr>
             <td>
-							<a href="download/${e.name}">${h.escape(e.name)}</a>
+							<a href="download/${e.link}">${h.escape(e.name)}</a>
             </td>
             <td>
               <a href="${rootURL}/fingerprint/${e.fingerprint}/">

--- a/src/test/java/hudson/plugins/s3/FingerprintRecordTest.java
+++ b/src/test/java/hudson/plugins/s3/FingerprintRecordTest.java
@@ -1,0 +1,24 @@
+package hudson.plugins.s3;
+
+import org.junit.Test;
+
+import java.net.URLDecoder;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+public class FingerprintRecordTest {
+
+    @Test
+    public void testGetLink() throws Exception {
+        String windowsPath = "path\\to\\windows\\test.txt";
+        FingerprintRecord windowsRecord = new FingerprintRecord(true, "test", windowsPath, "us-eat-1", "xxxx");
+        String link = windowsRecord.getLink();
+        String linkDecoded = URLDecoder.decode(link, "utf-8");
+        assertNotEquals("link is encoded", windowsPath, link);
+        assertEquals("should match file name", windowsPath, linkDecoded);
+        String unixPath = "/path/tmp/abc";
+        FingerprintRecord unixRecord = new FingerprintRecord(true, "test", unixPath, "us-eat-1", "xxxx");
+        assertEquals("should match file name", unixPath, unixRecord.getLink());
+    }
+}


### PR DESCRIPTION
Chrome and IE convert \ to / and caused s3 plugin can not [match the artifact by name](https://github.com/jenkinsci/s3-plugin/blob/2ee479a22628bc5f06ab9f4e14efd096f3aab405/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java#L73), escape / with %5c will fix the issue

 [reference](https://bugs.chromium.org/p/chromium/issues/detail?id=25916) 