### PR TITLE
Add job setting to suppress console logging

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -43,6 +43,8 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
     private boolean dontWaitForConcurrentBuildCompletion;
 
+    private boolean suppressLogging;
+
     /**
      * User metadata key/value pairs to tag the upload with.
      */
@@ -50,7 +52,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
     @DataBoundConstructor
     public S3BucketPublisher(String profileName, List<Entry> entries, List<MetadataPair> userMetadata,
-                             boolean dontWaitForConcurrentBuildCompletion) {
+                             boolean dontWaitForConcurrentBuildCompletion, boolean suppressLogging) {
         if (profileName == null) {
             // defaults to the first one
             final S3Profile[] sites = DESCRIPTOR.getProfiles();
@@ -66,6 +68,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         this.userMetadata = userMetadata;
 
         this.dontWaitForConcurrentBuildCompletion = dontWaitForConcurrentBuildCompletion;
+        this.suppressLogging = suppressLogging;
     }
 
     protected Object readResolve() {
@@ -94,6 +97,11 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         return dontWaitForConcurrentBuildCompletion;
     }
 
+    @SuppressWarnings("unused")
+    public boolean isSuppressLogging() {
+        return suppressLogging;
+    }
+
     public S3Profile getProfile() {
         return getProfile(profileName);
     }
@@ -119,7 +127,9 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     }
 
     private void log(final PrintStream logger, final String message) {
-        logger.println(StringUtils.defaultString(getDescriptor().getDisplayName()) + ' ' + message);
+        if(! suppressLogging) {
+            logger.println(StringUtils.defaultString(getDescriptor().getDisplayName()) + ' ' + message);
+        }
     }
 
     @Override

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -68,7 +68,15 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         this.userMetadata = userMetadata;
 
         this.dontWaitForConcurrentBuildCompletion = dontWaitForConcurrentBuildCompletion;
-        this.consoleLogLevel = Level.parse(consoleLogLevel);
+        this.consoleLogLevel = parseLevel(consoleLogLevel);
+    }
+
+    private Level parseLevel(String lvl) {
+        switch (lvl) {
+        case "WARNING": return Level.WARNING;
+        case "SEVERE":  return Level.SEVERE;
+        default:        return Level.INFO;
+        }
     }
 
     protected Object readResolve() {

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -29,7 +29,7 @@
     <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3" />
   </f:entry>
 
-  <f:entry field="suppressLogging" title="">
-    <f:checkbox title="Don't log to build console" />
+  <f:entry title="Build console log level" field="consoleLogLevel">
+    <f:select />
   </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -28,4 +28,8 @@
   <f:entry field="dontWaitForConcurrentBuildCompletion" title="">
     <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3" />
   </f:entry>
+
+  <f:entry field="suppressLogging" title="">
+    <f:checkbox title="Don't log to build console" />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-consoleLogLevel.html
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-consoleLogLevel.html
@@ -1,0 +1,3 @@
+<div>
+    Allows filtering log messages by level of severity: INFO, WARNING and SEVERE.
+</div>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-suppressLogging.html
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-suppressLogging.html
@@ -1,3 +1,0 @@
-<div>
-    When enabled, refrain from logging S3 Bucket actions to build console output.
-</div>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-suppressLogging.html
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-suppressLogging.html
@@ -1,0 +1,3 @@
+<div>
+    When enabled, refrain from logging S3 Bucket actions to build console output.
+</div>


### PR DESCRIPTION
This plugin is really noisy when you have loads of assets to archive,
so this adds a toggle to suppress all output to the build console.