### PR TITLE
JENKINS-27284: Constrain build result severity

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -44,6 +44,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     private boolean dontWaitForConcurrentBuildCompletion;
 
     private Level consoleLogLevel;
+    private Result pluginFailureResultConstraint;
 
     /**
      * User metadata key/value pairs to tag the upload with.
@@ -52,7 +53,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
     @DataBoundConstructor
     public S3BucketPublisher(String profileName, List<Entry> entries, List<MetadataPair> userMetadata,
-                             boolean dontWaitForConcurrentBuildCompletion, String consoleLogLevel) {
+                             boolean dontWaitForConcurrentBuildCompletion, String consoleLogLevel, String pluginFailureResultConstraint) {
         if (profileName == null) {
             // defaults to the first one
             final S3Profile[] sites = DESCRIPTOR.getProfiles();
@@ -69,6 +70,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
         this.dontWaitForConcurrentBuildCompletion = dontWaitForConcurrentBuildCompletion;
         this.consoleLogLevel = parseLevel(consoleLogLevel);
+        this.pluginFailureResultConstraint = Result.fromString(pluginFailureResultConstraint);
     }
 
     private Level parseLevel(String lvl) {
@@ -85,6 +87,15 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         return this;
     }
 
+    private Result constrainResult(Result r, @Nonnull TaskListener listener) {
+        final PrintStream console = listener.getLogger();
+        if (r.isWorseThan(pluginFailureResultConstraint)) {
+            log(console, "Build result constrained by configuration to: " + pluginFailureResultConstraint + " from: " + Result.UNSTABLE);
+            return pluginFailureResultConstraint;
+        }
+        return r;
+    }
+
     @SuppressWarnings("unused")
     public List<Entry> getEntries() {
         return entries;
@@ -98,6 +109,11 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     @SuppressWarnings("unused")
     public String getProfileName() {
         return this.profileName;
+    }
+
+    @SuppressWarnings("unused")
+    public Result getPluginFailureResultConstraint() {
+        return this.pluginFailureResultConstraint;
     }
 
     @SuppressWarnings("unused")
@@ -161,7 +177,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
         if (profile == null) {
             log(Level.SEVERE, console, "No S3 profile is configured.");
-            run.setResult(Result.UNSTABLE);
+            run.setResult(constrainResult(Result.UNSTABLE, listener));
             return;
         }
 
@@ -236,9 +252,9 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
                 run.addAction(new S3ArtifactsAction(run, profile, artifacts));
                 run.addAction(new FingerprintAction(run, record));
             }
-        } catch (IOException e) {
+        } catch (Exception e) { // Any failure in this plugin should be constrained according to config
             e.printStackTrace(listener.error("Failed to upload files"));
-            run.setResult(Result.UNSTABLE);
+            run.setResult(constrainResult(Result.UNSTABLE, listener));
         }
     }
 
@@ -330,6 +346,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         private final CopyOnWriteList<S3Profile> profiles = new CopyOnWriteList<S3Profile>();
         public static final Level[] consoleLogLevels = { Level.INFO, Level.WARNING, Level.SEVERE };
         private static final Logger LOGGER = Logger.getLogger(DescriptorImpl.class.getName());
+        private static final Result[] pluginFailureResultConstraints = { Result.SUCCESS, Result.UNSTABLE, Result.FAILURE };
 
         public DescriptorImpl(Class<? extends Publisher> clazz) {
             super(clazz);
@@ -384,6 +401,15 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         }
 
         @SuppressWarnings("unused")
+        public ListBoxModel doFillPluginFailureResultConstraintItems() {
+            final ListBoxModel model = new ListBoxModel();
+            for (Result r : pluginFailureResultConstraints) {
+                model.add(r.toString(), r.toString());
+            }
+            return model;
+        }
+
+        @SuppressWarnings("unused")
         public void replaceProfiles(List<S3Profile> profiles) {
             this.profiles.replaceBy(profiles);
             save();
@@ -396,6 +422,10 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         public S3Profile[] getProfiles() {
             final S3Profile[] profileArray = new S3Profile[profiles.size()];
             return profiles.toArray(profileArray);
+        }
+
+        public Result[] getPluginFailureResultConstraints() {
+            return pluginFailureResultConstraints;
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -1,6 +1,6 @@
 package hudson.plugins.s3;
 
-import com.amazonaws.AmazonServiceException;
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.google.common.collect.ImmutableList;
@@ -259,7 +259,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
                 run.addAction(new S3ArtifactsAction(run, profile, artifacts));
                 run.addAction(new FingerprintAction(run, record));
             }
-        } catch (Exception e) { // Any failure in this plugin should be constrained according to config
+        } catch (AmazonClientException|IOException e) {
             e.printStackTrace(listener.error("Failed to upload files"));
             run.setResult(constrainResult(Result.UNSTABLE, listener));
         }
@@ -463,7 +463,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
             try {
                 client.listBuckets();
-            } catch (AmazonServiceException e) {
+            } catch (AmazonClientException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);
                 return FormValidation.error("Can't connect to S3 service: " + e.getMessage());
             }

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -25,6 +25,10 @@
     </f:repeatableProperty>
   </f:entry>
 
+  <f:entry title="Publish Failure Result Constraint" field="pluginFailureResultConstraint">
+    <f:select />
+  </f:entry>
+
   <f:entry field="dontWaitForConcurrentBuildCompletion" title="">
     <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3" />
   </f:entry>


### PR DESCRIPTION
This change adds a per-job setting to constrain the build result
nastiness set by the plugin for problems that occur inside the plugin.
That is, an S3 failure that would normally result in a FAILURE can
be constrained to UNSTABLE or SUCCESS.

This addresses JENKINS-27284
<https://issues.jenkins-ci.org/browse/JENKINS-27284> by providing a
way to prevent S3 plugin failures from causing an otherwise successful
build to be marked as having failed.