### PR TITLE
Add Standard - Infrequent Access storage class

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -26,9 +26,9 @@ public final class Entry implements Describable<Entry> {
      */
     public String excludedFile;
     /**
-     * options for x-amz-storage-class can be STANDARD or REDUCED_REDUNDANCY
+     * options for x-amz-storage-class can be STANDARD, STANDARD_IA, or REDUCED_REDUNDANCY
      */
-    public static final String[] storageClasses = {"STANDARD", "REDUCED_REDUNDANCY"};
+    public static final String[] storageClasses = {"STANDARD", "STANDARD_IA", "REDUCED_REDUNDANCY"};
     /**
      * what x-amz-storage-class is currently set
      */


### PR DESCRIPTION
Adds the STANDARD_IA storage class option to the existing two options.

http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html#RESTObjectPUT-requests

https://aws.amazon.com/blogs/aws/aws-storage-update-new-lower-cost-s3-storage-option-glacier-price-reduction/
