### PR TITLE
[JENKINS-40654] Make plugin compatible with storage backends compatible with Amazon S3 (OpenStack Swift...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ and a post-build action called `Publish Artifacts to S3 Bucket`.
 For Pipeline users, the same two actions are available via the
 `step` step. You can use the snippet generator to get started.
 
+When using an Amazon S3 compatible storage system (OpenStack Swift, EMC Atmos...),
+the list of AWS regions can be overridden specifying a file 
+`classpath://com/amazonaws/partitions/override/endpoints.json` matching the format 
+defined in AWS SDK's [endpoints.json](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/resources/com/amazonaws/partitions/endpoints.json).
+
+A solution to add this `endpoints.json` file in the classpath of Jenkins is to use the 
+`java` command line parameter `-Xbootclasspath/a:/path/to/boot/classpath/folder/` and 
+to locate `com/amazonaws/partitions/override/endpoints.json` in `/path/to/boot/classpath/folder/`.
+
+
+Even if most of the features of the Jenkins S3 Plugin require the user to specify the target region,
+some feature rely on a default Amazon S3 region which is by default the "US Standard Amazon S3 Region" 
+and its endpoint `s3.amazonaws.com`. This default region can be overridden with the system property 
+`hudson.plugins.s3.DEFAULT_AMAZON_S3_REGION`. 
+Note that this default region name MUST match with a region define in the AWS SDK configuration file `endpoints.json`
+(see above).
+
 Notes
 =====
 

--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -2,7 +2,6 @@ package hudson.plugins.s3;
 
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import hudson.Extension;
 import hudson.model.Describable;

--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -1,6 +1,9 @@
 package hudson.plugins.s3;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -36,7 +39,7 @@ public final class Entry implements Describable<Entry> {
     /**
      * Regions Values
      */
-    public static final Regions[] regions = Regions.values();
+    public static final List<Region> regions = RegionUtils.getRegionsForService(AmazonS3.ENDPOINT_PREFIX);
     /**
      * Stores the Region Value
      */
@@ -134,7 +137,7 @@ public final class Entry implements Describable<Entry> {
 
         public ListBoxModel doFillSelectedRegionItems() {
             final ListBoxModel model = new ListBoxModel();
-            for (Regions r : regions) {
+            for (Region r : regions) {
                 model.add(r.getName(), r.getName());
             }
             return model;

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -1,7 +1,7 @@
 package hudson.plugins.s3;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.regions.Regions;
+import com.amazonaws.regions.Region;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -365,7 +365,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
             load();
         }
 
-        public Regions[] regions = Entry.regions;
+        public List<Region> regions = Entry.regions;
 
         public String[] storageClasses = Entry.storageClasses;
 


### PR DESCRIPTION
[JENKINS-40654] Make plugin compatible with storage backends compatible with Amazon S3 (OpenStack Swift...)

Load the list of Amazon S3 regions from `c.a.r.RegionMetadataProvider`, stop relying on a static lists and constants.

* Adapt the http proxy logic of the plugin to discover the S3 endpoint hostname with `com.amazonaws.regions.Region#getServiceEndpoint("s3")` instead of the hardcoded constant `s3.amazonaws.com`
* Replace
   * `com.amazonaws.regions.Regions` by `com.amazonaws.regions.RegionUtils#getRegionsForService("s3")`
   * `com.amazonaws.services.s3.model.Region` by `com.amazonaws.regions.Region`
* For the default region used in some places of the plugin, introduce the system property `hudson.plugins.s3.DEFAULT_AMAZON_S3_REGION` to override the default `us-east-1`. Note that it would be better to no longer rely on a default AWS Region and to ask the user to specify the desired AWS Region.

The list of AWS regions can be overridden specifying a file `classpath://com/amazonaws/partitions/override/endpoints.json` matching the format defined in https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/resources/com/amazonaws/partitions/endpoints.json .

A solution to add this file in the classpath of Jenkins is to use the `java` command line parameter `-Xbootclasspath/a:/path/to/boot/classpath/folder/` and to locate `com/amazonaws/partitions/override/endpoints.json` in `/path/to/boot/classpath/folder/`.