### PR TITLE
add build status icon badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/s3-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/s3-plugin/)
 
 Install
 =======


### PR DESCRIPTION
Added the markdown badge from the badge page for the job: https://jenkins.ci.cloudbees.com/job/plugins/job/s3-plugin/badge/

This will help expose the location of the official build, its build status, and results of the unit tests.