### PR TITLE
Delete temporary gzip files after use.

### DIFF
--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -21,7 +21,7 @@ public final class Uploads {
     private final transient HashMap<FilePath, Upload> startedUploads = new HashMap<>();
     private final transient HashMap<FilePath, InputStream> openedStreams = new HashMap<>();
 
-    public void startUploading(TransferManager manager, FilePath file, InputStream inputsStream, String bucketName, String objectName, ObjectMetadata metadata) throws AmazonServiceException {
+    public Upload startUploading(TransferManager manager, FilePath file, InputStream inputsStream, String bucketName, String objectName, ObjectMetadata metadata) throws AmazonServiceException {
         final PutObjectRequest request = new PutObjectRequest(bucketName, objectName, inputsStream, metadata);
 
         // Set the buffer size (ReadLimit) equal to the multipart upload size,
@@ -32,6 +32,7 @@ public final class Uploads {
         final Upload upload = manager.upload(request);
         startedUploads.put(file, upload);
         openedStreams.put(file, inputsStream);
+        return upload;
     }
 
     public void finishUploading(FilePath filePath) throws InterruptedException {

--- a/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
@@ -1,6 +1,9 @@
 package hudson.plugins.s3.callable;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.event.ProgressListener;
+import com.amazonaws.event.ProgressEvent;
 import hudson.FilePath;
 import hudson.ProxyConfiguration;
 import hudson.plugins.s3.Destination;
@@ -21,23 +24,47 @@ public final class S3GzipCallable extends S3BaseUploadCallable implements Master
     @Override
     public String invoke(FilePath file) throws IOException, InterruptedException {
         final File localFile = File.createTempFile("s3plugin", ".bin");
+        Upload upload = null;
 
-        try (InputStream inputStream = file.read()) {
-            try (OutputStream outputStream = new FileOutputStream(localFile)) {
-                try (OutputStream gzipStream = new GZIPOutputStream(outputStream, true)) {
-                    IOUtils.copy(inputStream, gzipStream);
-                    gzipStream.flush();
+        try {
+            try (InputStream inputStream = file.read()) {
+                try (OutputStream outputStream = new FileOutputStream(localFile)) {
+                    try (OutputStream gzipStream = new GZIPOutputStream(outputStream, true)) {
+                        IOUtils.copy(inputStream, gzipStream);
+                        gzipStream.flush();
+                    }
                 }
             }
+
+            final InputStream gzipedStream = new FileInputStream(localFile);
+            final ObjectMetadata metadata = buildMetadata(file);
+            metadata.setContentEncoding("gzip");
+            metadata.setContentLength(localFile.length());
+
+            upload = Uploads.getInstance().startUploading(getTransferManager(), file, gzipedStream, getDest().bucketName, getDest().objectName, metadata);
+
+            String md5 = MD5.generateFromFile(localFile);
+
+            upload.addProgressListener(new ProgressListener() {
+                    @Override
+                    public void progressChanged(ProgressEvent event) {
+                        switch (event.getEventType()) {
+                        case TRANSFER_CANCELED_EVENT:
+                        case TRANSFER_COMPLETED_EVENT:
+                        case TRANSFER_FAILED_EVENT:
+                            localFile.delete();
+                        }
+                    }
+                });
+            return md5;
+        } finally {
+            // The upload might have finished before we installed the progress listener.
+            if (upload == null || upload.isDone()) {
+                // The progress listener may have fired before this,
+                // but .delete() on non-existent path is ok, and the
+                // temporary name won't be reused by anything
+                localFile.delete();
+            }
         }
-
-        final InputStream gzipedStream = new FileInputStream(localFile);
-        final ObjectMetadata metadata = buildMetadata(file);
-        metadata.setContentEncoding("gzip");
-        metadata.setContentLength(localFile.length());
-
-        Uploads.getInstance().startUploading(getTransferManager(), file, gzipedStream, getDest().bucketName, getDest().objectName, metadata);
-
-        return MD5.generateFromFile(localFile);
     }
 }


### PR DESCRIPTION
When gzip-compressing files before uploading, the S3 plugin left temporary files that could eventually fill the entire filesystem. This PR fixes that by ensuring that the temporary file is deleted after uploading it to S3 has finished.

This is accompanied by a minor API change: `Uploads.startUploading` now returns the `Upload` object for the initiated transfer. This is needed so that a deletion hook can be attached to it.
