### PR TITLE
Fix not uploading due to not being able to parse XML Document

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -213,7 +213,8 @@ public class S3Profile {
 
         final ListObjectsRequest listObjectsRequest = new ListObjectsRequest()
         .withBucketName(dest.bucketName)
-        .withPrefix(dest.objectName);
+        .withPrefix(dest.objectName)
+        .withEncodingType("url");
 
         final List<String> files = Lists.newArrayList();
 


### PR DESCRIPTION
Original issue is reported in AWS-S3-SDK as https://github.com/aws/aws-sdk-java/issues/460
The fix backported here is https://github.com/aws/aws-sdk-java/issues/460#issuecomment-233052127.
The issue is resolved by also upgrading the AWS-S3-SDK, however this would introduce more than
one breaking change, therefore setting explicitly `encodingType` to `url` is better for the situation.

@Jimilian 