### PR TITLE
S3BaseUploadCallable: add missing break for 'content-type'

### DIFF
--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -77,6 +77,7 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
                     break;
                 case "content-type":
                     metadata.setContentType(entry.getValue());
+                    break;
                 default:
                     metadata.addUserMetadata(entry.getKey(), entry.getValue());
                     break;


### PR DESCRIPTION
When handling the metadata for the object getting pushed to S3, the
special case of `content-type` appears to be missing a break.  This
causes the object to have the `Content-Type` header and the
`x-amz-meta-content-type` header.

While this doesn't seem to break anything, I believe it is the correct
way to do this.