### PR TITLE
fix JENKINS-46048 Improve support for Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ build action called `S3 Copy Artifact` for downloading artifacts,
 and a post-build action called `Publish Artifacts to S3 Bucket`.
 
 For Pipeline users, the same two actions are available via the
-`step` step. You can use the snippet generator to get started.
+`s3CopyArtifact` and `s3Upload` step. You can use the snippet generator to get started.
 
 When using an Amazon S3 compatible storage system (OpenStack Swift, EMC Atmos...),
 the list of AWS regions can be overridden specifying a file 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>maven-plugin</artifactId>
             <version>2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.2</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -22,6 +22,7 @@ import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -126,12 +127,17 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         return this.profileName;
     }
 
+    /**
+     * for data binding only
+     *
+     * @return pluginFailureResultConstraint string representation
+     */
     @SuppressWarnings("unused")
-    public Result getPluginFailureResultConstraint() {
+    public String getPluginFailureResultConstraint() {
         if (pluginFailureResultConstraint == null) {
-            return Result.FAILURE;
+            return Result.FAILURE.toString();
         }
-        return pluginFailureResultConstraint;
+        return pluginFailureResultConstraint.toString();
     }
 
     @SuppressWarnings("unused")
@@ -139,9 +145,14 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         return dontWaitForConcurrentBuildCompletion;
     }
 
+    /**
+     * for data binding only
+     *
+     * @return consoleLogLevel string representation
+     */
     @SuppressWarnings("unused")
-    public Level getConsoleLogLevel() {
-        return consoleLogLevel;
+    public String getConsoleLogLevel() {
+        return consoleLogLevel.toString();
     }
 
     public S3Profile getProfile() {
@@ -377,6 +388,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         return dontWaitForConcurrentBuildCompletion ? BuildStepMonitor.NONE : BuildStepMonitor.STEP;
     }
 
+    @Symbol("s3Upload")
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
         private final CopyOnWriteList<S3Profile> profiles = new CopyOnWriteList<S3Profile>();

--- a/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
+++ b/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
@@ -63,6 +63,7 @@ import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -301,6 +302,7 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
     }
 
     @Extension
+    @Symbol("s3CopyArtifact")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         public FormValidation doCheckProjectName(


### PR DESCRIPTION
* consoleLogLevel and pluginFailureResultConstraint type mismatch in constructor and getter, caused warning in data binding, and user had to set consoleLogLevel and pluginFailureResultConstraint explicitly, reported in JENKINS-40786
* I added s3CopyArtifact and s3Upload step, but I am not good at naming, feel free to change it.