### PR TITLE
Single-file upload option

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -70,6 +70,11 @@ public final class Entry implements Describable<Entry> {
     public boolean flatten;
 
     /**
+     * Upload a single file (so the file-name is not appended to the destination bucket)
+     */
+    public boolean singleFile;
+
+    /**
     * use GZIP to compress files
     */
     public boolean gzipFiles;
@@ -93,8 +98,8 @@ public final class Entry implements Describable<Entry> {
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String excludedFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten, boolean gzipFiles, boolean keepForever,
-                 boolean showDirectlyInBrowser, List<MetadataPair> userMetadata) {
+                 boolean useServerSideEncryption, boolean flatten, boolean singleFile, boolean gzipFiles,
+                 boolean keepForever, boolean showDirectlyInBrowser, List<MetadataPair> userMetadata) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.excludedFile = excludedFile;
@@ -105,6 +110,7 @@ public final class Entry implements Describable<Entry> {
         this.managedArtifacts = managedArtifacts;
         this.useServerSideEncryption = useServerSideEncryption;
         this.flatten = flatten;
+        this.singleFile = singleFile;
         this.gzipFiles = gzipFiles;
         this.keepForever = keepForever;
         this.userMetadata = userMetadata;

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -248,7 +248,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
                         final int workspacePath = FileHelper.getSearchPathLength(ws.getRemote(),
                                 startPath.trim(),
                                 getProfile().isKeepStructure());
-                        filenames.add(getFilename(path, entry.flatten, workspacePath));
+                        filenames.add(entry.singleFile ? null : getFilename(path, entry.flatten, workspacePath));
                         log(console, "bucket=" + bucket + ", file=" + path.getName() + " region=" + selRegion + ", will be uploaded from slave=" + entry.uploadFromSlave + " managed=" + entry.managedArtifacts + " , server encryption " + entry.useServerSideEncryption);
                     }
                 }

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -1,5 +1,6 @@
 package hudson.plugins.s3;
 
+import com.google.common.base.Joiner;
 import hudson.FilePath;
 
 import java.io.IOException;
@@ -116,7 +117,7 @@ public class S3Profile {
     }
 
     public List<FingerprintRecord> upload(Run<?, ?> run,
-                                    final String bucketName,
+                                    final String mainBucketName,
                                     final List<FilePath> filePaths,
                                     final List<String> fileNames,
                                     final Map<String, String> userMetadata,
@@ -131,7 +132,21 @@ public class S3Profile {
         try {
             for (int i = 0; i < fileNames.size(); i++) {
                 final FilePath filePath = filePaths.get(i);
-                final String fileName = fileNames.get(i);
+                final String bucketName;
+                final String fileName;
+                if (fileNames.get(i) == null) {
+                    final String[] bucketNameArray = mainBucketName.split("/");
+                    if (bucketNameArray.length > 1) {
+                        fileName = bucketNameArray[bucketNameArray.length - 1];
+                        bucketNameArray[bucketNameArray.length - 1] = null;
+                        bucketName = Joiner.on('/').skipNulls().join(bucketNameArray);
+                    } else {
+                        throw new IllegalArgumentException("Destination bucket must contains file name when Single file is enabled");
+                    }
+                } else {
+                    bucketName = mainBucketName;
+                    fileName = fileNames.get(i);
+                }
 
                 final Destination dest;
                 final boolean produced;

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -31,6 +31,9 @@
         <f:entry field="flatten" title="Flatten directories">
 		    <f:checkbox />
         </f:entry>
+        <f:entry field="singleFile" title="Single file">
+		        <f:checkbox />
+        </f:entry>
         <f:entry field="gzipFiles" title="GZIP files">
             <f:checkbox />
         </f:entry>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-singleFile.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-singleFile.html
@@ -1,0 +1,5 @@
+<div>
+    When enabled, Jenkins will only upload the first file matching the selector.
+    The filename is ignored and not appended to the 'Destination bucket'; so the Destination bucket will be used as
+    final key for the uploaded file.
+</div>

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -72,7 +72,7 @@ public class S3Test {
     }
 
     private Entry entryForFile(String fileName) {
-        return new Entry("bucket", fileName, "", "", "", false, false, true, false, false, false, false, false, null);
+        return new Entry("bucket", fileName, "", "", "", false, false, true, false, false, false, false, false, false, null);
     }
 
     private Builder stepCreatingFile(String fileName) {


### PR DESCRIPTION
Currently, the name of the source files is always used as the name of the destination file.
But when we want to upload only one file with a specific name, we must rename it before; which is not practical.
This option allows to upload a single source file by specifying its name (the "Destination bucket" is used as a complete path).

*Used in production for several months. Works.*