### PR TITLE
Add possibility to assumeRole and canned ACL choice

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -3,6 +3,7 @@ package hudson.plugins.s3;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -43,7 +44,7 @@ public final class Entry implements Describable<Entry> {
      * Stores the Region Value
      */
     public String selectedRegion;
-    
+
     /**
      * Do not publish the artifacts when build fails
      */
@@ -58,11 +59,16 @@ public final class Entry implements Describable<Entry> {
      * Let Jenkins manage the S3 uploaded artifacts
      */
     public boolean managedArtifacts;
-    
+
     /**
      * Use S3 server side encryption when uploading the artifacts
      */
     public boolean useServerSideEncryption;
+
+    /**
+     * Use this canned ACL when uploading
+     */
+    public String cannedACL;
 
     /**
      * Flatten directories
@@ -93,7 +99,7 @@ public final class Entry implements Describable<Entry> {
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String excludedFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
-                 boolean useServerSideEncryption, boolean flatten, boolean gzipFiles, boolean keepForever,
+                 boolean useServerSideEncryption, String cannedACL, boolean flatten, boolean gzipFiles, boolean keepForever,
                  boolean showDirectlyInBrowser, List<MetadataPair> userMetadata) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
@@ -104,6 +110,7 @@ public final class Entry implements Describable<Entry> {
         this.uploadFromSlave = uploadFromSlave;
         this.managedArtifacts = managedArtifacts;
         this.useServerSideEncryption = useServerSideEncryption;
+        this.cannedACL = cannedACL;
         this.flatten = flatten;
         this.gzipFiles = gzipFiles;
         this.keepForever = keepForever;
@@ -130,6 +137,14 @@ public final class Entry implements Describable<Entry> {
             final ListBoxModel model = new ListBoxModel();
             for (String s : storageClasses) {
                 model.add(s, s);
+            }
+            return model;
+        }
+
+        public ListBoxModel doFillCannedACLItems() {
+            final ListBoxModel model = new ListBoxModel();
+            for (CannedAccessControlList cacl : CannedAccessControlList.values()) {
+                model.add(cacl.toString(), cacl.name());
             }
             return model;
         }

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -33,6 +33,7 @@ import java.io.PrintStream;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 public final class S3BucketPublisher extends Recorder implements SimpleBuildStep {
 
@@ -262,7 +263,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
                 final Map<String, String> escapedMetadata = buildMetadata(envVars, entry);
 
                 final List<FingerprintRecord> records = Lists.newArrayList();
-                final List<FingerprintRecord> fingerprints = profile.upload(run, bucket, paths, filenames, escapedMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.gzipFiles);
+                final List<FingerprintRecord> fingerprints = profile.upload(run, bucket, paths, filenames, escapedMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.cannedACL, entry.gzipFiles);
 
                 for (FingerprintRecord fingerprintRecord : fingerprints) {
                     records.add(fingerprintRecord);
@@ -502,7 +503,45 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
             final String defaultRegion = ClientHelper.DEFAULT_AMAZON_S3_REGION_NAME;
             final AmazonS3Client client = ClientHelper.createClient(
-                    accessKey, secretKey, useRole, defaultRegion, Jenkins.getActiveInstance().proxy);
+                    accessKey, secretKey, useRole, "", defaultRegion, Jenkins.getActiveInstance().proxy);
+
+            try {
+                client.listBuckets();
+            } catch (AmazonClientException e) {
+                LOGGER.log(Level.SEVERE, e.getMessage(), e);
+                return FormValidation.error("Can't connect to S3 service: " + e.getMessage());
+            }
+            return FormValidation.ok("Check passed!");
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doAssumeRoleArnCheck(final StaplerRequest req, StaplerResponse rsp) {
+            final String assumeRoleArn = Util.fixNull(req.getParameter("assumeRoleArn"));
+            if (assumeRoleArn.isEmpty()) {
+                return FormValidation.ok();
+            }
+            if (!Pattern.matches("(?i)arn:aws:iam::\\d+:role/.+", assumeRoleArn.toLowerCase())) {
+                return FormValidation.error("Does not look like a ARN");
+            }
+
+            final String useIAMCredential = Util.fixNull(req.getParameter("useRole"));
+            final boolean useRole = Boolean.parseBoolean(useIAMCredential);
+            if (useRole) {
+                // Won't be able to validate this because IAM role on master could be different on slave(s)
+                return FormValidation.ok();
+            }
+
+            final String accessKey = Util.fixNull(req.getParameter("accessKey"));
+            if (accessKey.isEmpty())
+                return FormValidation.ok("Please, enter accessKey");
+
+            final String secretKey = Util.fixNull(req.getParameter("secretKey"));
+            if (secretKey.isEmpty())
+                return FormValidation.ok("Please, enter secretKey");
+
+            final String defaultRegion = ClientHelper.DEFAULT_AMAZON_S3_REGION_NAME;
+            final AmazonS3Client client = ClientHelper.createClient(
+                    accessKey, secretKey, useRole, assumeRoleArn, defaultRegion, Jenkins.getActiveInstance().proxy);
 
             try {
                 client.listBuckets();

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -1,6 +1,7 @@
 package hudson.plugins.s3;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
@@ -21,8 +22,12 @@ public final class Uploads {
     private final transient HashMap<FilePath, Upload> startedUploads = new HashMap<>();
     private final transient HashMap<FilePath, InputStream> openedStreams = new HashMap<>();
 
-    public Upload startUploading(TransferManager manager, FilePath file, InputStream inputsStream, String bucketName, String objectName, ObjectMetadata metadata) throws AmazonServiceException {
+    public Upload startUploading(TransferManager manager, FilePath file, InputStream inputsStream, String bucketName, String objectName, ObjectMetadata metadata, CannedAccessControlList cannedAcl) throws AmazonServiceException {
         final PutObjectRequest request = new PutObjectRequest(bucketName, objectName, inputsStream, metadata);
+
+        if (!cannedAcl.equals(CannedAccessControlList.Private)) {
+            request.setCannedAcl(cannedAcl);
+        }
 
         // Set the buffer size (ReadLimit) equal to the multipart upload size,
         // allowing us to resend data if the connection breaks.

--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -1,6 +1,7 @@
 package hudson.plugins.s3.callable;
 
 import com.amazonaws.services.s3.internal.Mimetypes;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import hudson.FilePath;
 import hudson.ProxyConfiguration;
@@ -21,16 +22,18 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
     private final String storageClass;
     private final Map<String, String> userMetadata;
     private final boolean useServerSideEncryption;
+    private final String cannedACLName;
 
 
-    public S3BaseUploadCallable(String accessKey, Secret secretKey, boolean useRole,
+    public S3BaseUploadCallable(String accessKey, Secret secretKey, boolean useRole, String assumeRoleArn,
                                 Destination dest, Map<String, String> userMetadata, String storageClass, String selregion,
-                                boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, selregion, proxy);
+                                boolean useServerSideEncryption, String cannedACLName, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, assumeRoleArn, selregion, proxy);
         this.dest = dest;
         this.storageClass = storageClass;
         this.userMetadata = userMetadata;
         this.useServerSideEncryption = useServerSideEncryption;
+        this.cannedACLName = cannedACLName;
     }
 
     /**
@@ -88,5 +91,12 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
 
     public Destination getDest() {
         return dest;
+    }
+
+    public CannedAccessControlList getCannedAcl() {
+        if (cannedACLName == null) {
+            return CannedAccessControlList.Private;
+        }
+        return CannedAccessControlList.valueOf(cannedACLName);
     }
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3Callable.java
@@ -16,15 +16,17 @@ abstract class S3Callable<T> implements FileCallable<T> {
     private final String accessKey;
     private final Secret secretKey;
     private final boolean useRole;
+    private final String assumeRoleArn;
     private final String region;
     private final ProxyConfiguration proxy;
 
     private static transient HashMap<String, TransferManager> transferManagers = new HashMap<>();
 
-    S3Callable(String accessKey, Secret secretKey, boolean useRole, String region, ProxyConfiguration proxy) {
+    S3Callable(String accessKey, Secret secretKey, boolean useRole, String assumeRoleArn, String region, ProxyConfiguration proxy) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.useRole = useRole;
+        this.assumeRoleArn = assumeRoleArn;
         this.region = region;
         this.proxy = proxy;
     }
@@ -32,7 +34,7 @@ abstract class S3Callable<T> implements FileCallable<T> {
     protected synchronized TransferManager getTransferManager() {
         final String uniqueKey = getUniqueKey();
         if (transferManagers.get(uniqueKey) == null) {
-            final AmazonS3 client = ClientHelper.createClient(accessKey, Secret.toString(secretKey), useRole, region, proxy);
+            final AmazonS3 client = ClientHelper.createClient(accessKey, Secret.toString(secretKey), useRole, assumeRoleArn, region, proxy);
             transferManagers.put(uniqueKey, new TransferManager(client));
         }
 
@@ -45,6 +47,6 @@ abstract class S3Callable<T> implements FileCallable<T> {
     }
 
     private String getUniqueKey() {
-        return region + '_' + secretKey + '_' + accessKey + '_' + useRole;
+        return region + '_' + secretKey + '_' + accessKey + '_' + useRole + '_' + assumeRoleArn;
     }
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -16,9 +16,9 @@ public final class S3DownloadCallable extends S3Callable<String>
     private static final long serialVersionUID = 1L;
     private final Destination dest;
     
-    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, String region, ProxyConfiguration proxy)
+    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, String assumeRoleArn, Destination dest, String region, ProxyConfiguration proxy)
     {
-        super(accessKey, secretKey, useRole, region, proxy);
+        super(accessKey, secretKey, useRole, assumeRoleArn, region, proxy);
         this.dest = dest;
     }
 

--- a/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
@@ -1,5 +1,6 @@
 package hudson.plugins.s3.callable;
 
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.event.ProgressListener;
@@ -17,8 +18,8 @@ import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 public final class S3GzipCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
-    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, String assumeRoleArn, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, String cannedACL, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, assumeRoleArn, dest, userMetadata, storageClass, selregion, useServerSideEncryption, cannedACL, proxy);
     }
 
     // Return a File containing the gzipped contents of the input file.
@@ -67,8 +68,9 @@ public final class S3GzipCallable extends S3BaseUploadCallable implements Master
             final ObjectMetadata metadata = buildMetadata(file);
             metadata.setContentEncoding("gzip");
             metadata.setContentLength(localFile.length());
+            final CannedAccessControlList cannedAcl = getCannedAcl();
 
-            upload = Uploads.getInstance().startUploading(getTransferManager(), file, gzipedStream, getDest().bucketName, getDest().objectName, metadata);
+            upload = Uploads.getInstance().startUploading(getTransferManager(), file, gzipedStream, getDest().bucketName, getDest().objectName, metadata, cannedAcl);
 
             String md5 = MD5.generateFromFile(localFile);
 

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -1,5 +1,6 @@
 package hudson.plugins.s3.callable;
 
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import hudson.FilePath;
 import hudson.ProxyConfiguration;
@@ -14,8 +15,8 @@ import java.util.Map;
 public final class S3UploadCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
     private static final long serialVersionUID = 1L;
 
-    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, String assumeRoleArn, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, String cannedACL, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, assumeRoleArn, dest, userMetadata, storageClass, selregion, useServerSideEncryption, cannedACL, proxy);
     }
 
     /**
@@ -24,8 +25,9 @@ public final class S3UploadCallable extends S3BaseUploadCallable implements Mast
     @Override
     public String invoke(FilePath file) throws IOException, InterruptedException {
         final ObjectMetadata metadata = buildMetadata(file);
+        final CannedAccessControlList cannedAcl = getCannedAcl();
 
-        Uploads.getInstance().startUploading(getTransferManager(), file, file.read(), getDest().bucketName, getDest().objectName, metadata);
+        Uploads.getInstance().startUploading(getTransferManager(), file, file.read(), getDest().bucketName, getDest().objectName, metadata, cannedAcl);
 
         return MD5.generateFromFile(file);
     }

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -28,6 +28,9 @@
         <f:entry field="useServerSideEncryption" title="Server side encryption">
 		    <f:checkbox />
         </f:entry>
+        <f:entry field="cannedACL" title="Use Canned ACL">
+            <f:select />
+        </f:entry>
         <f:entry field="flatten" title="Flatten directories">
 		    <f:checkbox />
         </f:entry>

--- a/src/main/resources/hudson/plugins/s3/Entry/help-cannedACL.html
+++ b/src/main/resources/hudson/plugins/s3/Entry/help-cannedACL.html
@@ -1,0 +1,5 @@
+<div>
+    Choose a canned ACL for uploaded objects. See possible values <a
+        href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl">here</a>. AWS default value
+    for new objects is <tt>private</tt>. Setting any other value requires to be granted <tt>PutObjectAcl</tt>.
+</div>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -23,6 +23,11 @@
                     onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()"
             />
           </f:entry>
+          <f:entry title="Assume role" help="/plugin/s3/help-assumeRoleArn.html">
+            <f:textbox name="s3.assumeRoleArn" value="${profile.assumeRoleArn}" checkMethod="post"
+                    checkUrl="'${rootURL}/publisher/S3BucketPublisher/assumeRoleArnCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)+'&amp;useRole='+encodeURIComponent(Form.findMatchingInput(this,'s3.useRole').value)"
+            />
+          </f:entry>
           <f:advanced>
             <f:entry title="Max upload retries">
                 <f:number name="s3.maxUploadRetries" value="${profile.maxUploadRetries}"/>

--- a/src/main/webapp/help-assumeRoleArn.html
+++ b/src/main/webapp/help-assumeRoleArn.html
@@ -1,0 +1,5 @@
+<div>If defined, ARN of an IAM role to assume to access S3.
+    <p>Use given credentials above (Access key and Secret key or instance IAM role) to get temporary credentials from
+        STS, assuming this role to access S3. This can be used to access cross-account buckets, by assuming a role
+        defined in another account.
+    </p></div>

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -38,7 +38,7 @@ public class S3Test {
 
     @Test
     public void testConfigContainsProfiles() throws Exception {
-        final S3Profile profile = new S3Profile("S3 profile random name", null, null, true, 0, "0", "0", "0", "0", true);
+        final S3Profile profile = new S3Profile("S3 profile random name", null, null, true, null,0, "0", "0", "0", "0", true);
 
         replaceS3PluginProfile(profile);
 
@@ -72,7 +72,7 @@ public class S3Test {
     }
 
     private Entry entryForFile(String fileName) {
-        return new Entry("bucket", fileName, "", "", "", false, false, true, false, false, false, false, false, null);
+        return new Entry("bucket", fileName, "", "", "", false, false, true, false, "", false, false, false, false, null);
     }
 
     private Builder stepCreatingFile(String fileName) {
@@ -100,6 +100,7 @@ public class S3Test {
                 Mockito.anyBoolean(),
                 Mockito.anyBoolean(),
                 Mockito.anyBoolean(),
+                Mockito.anyString(),
                 Mockito.anyBoolean()
         )).thenReturn(newArrayList(new FingerprintRecord(true, "bucket", "path", "eu-west-1", "xxxx")));
         return profile;


### PR DESCRIPTION
I needed my Jenkins to be able to put file on a bucket owned by another account. This requires being able to change ACL to bucket-owner-full-control and also assuming a role defined in the other account. This PR adds both possibilities.

