### PR TITLE
Add support for not setting build status on failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,15 @@
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -34,6 +34,10 @@
     <f:checkbox title="Don't wait for completion of concurrent builds before publishing to S3" />
   </f:entry>
 
+  <f:entry field="dontSetBuildResultOnFailure" title="">
+    <f:checkbox title="Do Not Set Build Result on Failure" />
+  </f:entry>
+
   <f:entry title="Build console log level" field="consoleLogLevel">
     <f:select />
   </f:entry>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-dontSetBuildResultOnFailure.html
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/help-dontSetBuildResultOnFailure.html
@@ -1,0 +1,6 @@
+<div>
+    When checked or selected, the build status will not get updated when a failure occurs.
+    This is primarily useful when using this step in a pipeline. A failure would manifest itself
+    as an exception thrown as opposed to a change in build status. Therefore, the pipeline author can
+    choose to decide to handle the exception with a retry(), etc.
+</div>

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -6,7 +6,9 @@ import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.Action;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Result;
 import hudson.model.Run;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.s3.S3BucketPublisher.DescriptorImpl;
 import hudson.tasks.Builder;
 import hudson.tasks.Fingerprinter.FingerprintAction;
@@ -56,7 +58,8 @@ public class S3Test {
                 Collections.<MetadataPair>emptyList(),
                 true,
                 "INFO",
-                "SUCCESS"
+                "SUCCESS",
+                false
         );
         replaceS3PluginProfile(mockS3Profile(profileName));
 
@@ -69,6 +72,31 @@ public class S3Test {
         final FreeStyleBuild build = j.buildAndAssertSuccess(project);
         assertEquals(1, countActionsOfType(build, S3ArtifactsAction.class));
         assertEquals(1, countActionsOfType(build, FingerprintAction.class));
+    }
+
+    @Test
+    public void dontSetBuildResultTest() throws Exception {
+        String profileName = "test profile";
+        String missingProfileName = "test profile missing";
+        String fileName = "testFile";
+        S3BucketPublisher missingPublisher = new S3BucketPublisher(
+                missingProfileName,
+                newArrayList(entryForFile(fileName)),
+                Collections.<MetadataPair>emptyList(),
+                true,
+                "DEBUG",
+                "SUCCESS",
+                true
+        );
+        replaceS3PluginProfile(mockS3Profile(profileName));
+
+        final FreeStyleProject project = j.createFreeStyleProject("testing");
+        project.getBuildersList().add(stepCreatingFile(fileName));
+
+        project.getPublishersList().add(missingPublisher);
+
+        QueueTaskFuture<FreeStyleBuild> r = project.scheduleBuild2(0);
+        j.assertBuildStatus(Result.FAILURE, r);
     }
 
     private Entry entryForFile(String fileName) {


### PR DESCRIPTION
- When this plugin is used in pipeline scripts, authors want to be able to catch errors and decide what should be done with the exceptions.
- Currently, the plugin sets the build status in many cases.
- This PR allows this behaviour to be overridden.
