### PR TITLE
Add Endpoint URL field to S3Profile

### DIFF
--- a/src/main/java/hudson/plugins/s3/ClientHelper.java
+++ b/src/main/java/hudson/plugins/s3/ClientHelper.java
@@ -19,7 +19,7 @@ public class ClientHelper {
             "hudson.plugins.s3.DEFAULT_AMAZON_S3_REGION",
             com.amazonaws.services.s3.model.Region.US_Standard.toAWSRegion().getName());
 
-    public static AmazonS3Client createClient(String accessKey, String secretKey, boolean useRole, String region, ProxyConfiguration proxy)
+    public static AmazonS3Client createClient(String accessKey, String secretKey, boolean useRole, String endpoint, String region, ProxyConfiguration proxy)
     {
         Region awsRegion = getRegionFromString(region);
 
@@ -33,6 +33,9 @@ public class ClientHelper {
         }
 
         client.setRegion(awsRegion);
+        if (endpoint != null && !endpoint.trim().isEmpty()){
+            client.setEndpoint(endpoint);
+        }
 
         return client;
     }

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -496,6 +496,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
             final String name = Util.fixNull(req.getParameter("name"));
             final String accessKey = Util.fixNull(req.getParameter("accessKey"));
             final String secretKey = Util.fixNull(req.getParameter("secretKey"));
+            final String endpoint = Util.fixNull(req.getParameter("endpoint"));
             final String useIAMCredential = Util.fixNull(req.getParameter("useRole"));
 
             final boolean couldBeValidated = !name.isEmpty() && !accessKey.isEmpty() && !secretKey.isEmpty();
@@ -517,7 +518,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
             final String defaultRegion = ClientHelper.DEFAULT_AMAZON_S3_REGION_NAME;
             final AmazonS3Client client = ClientHelper.createClient(
-                    accessKey, secretKey, useRole, defaultRegion, Jenkins.getActiveInstance().proxy);
+                    accessKey, secretKey, useRole, endpoint, defaultRegion, Jenkins.getActiveInstance().proxy);
 
             try {
                 client.listBuckets();

--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -23,10 +23,10 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
     private final boolean useServerSideEncryption;
 
 
-    public S3BaseUploadCallable(String accessKey, Secret secretKey, boolean useRole,
+    public S3BaseUploadCallable(String accessKey, Secret secretKey, boolean useRole, String endpoint,
                                 Destination dest, Map<String, String> userMetadata, String storageClass, String selregion,
                                 boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, selregion, proxy);
+        super(accessKey, secretKey, useRole, endpoint, selregion, proxy);
         this.dest = dest;
         this.storageClass = storageClass;
         this.userMetadata = userMetadata;

--- a/src/main/java/hudson/plugins/s3/callable/S3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3Callable.java
@@ -16,15 +16,17 @@ abstract class S3Callable<T> implements FileCallable<T> {
     private final String accessKey;
     private final Secret secretKey;
     private final boolean useRole;
+    private final String endpoint;
     private final String region;
     private final ProxyConfiguration proxy;
 
     private static transient HashMap<String, TransferManager> transferManagers = new HashMap<>();
 
-    S3Callable(String accessKey, Secret secretKey, boolean useRole, String region, ProxyConfiguration proxy) {
+    S3Callable(String accessKey, Secret secretKey, boolean useRole, String endpoint, String region, ProxyConfiguration proxy) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.useRole = useRole;
+        this.endpoint = endpoint;
         this.region = region;
         this.proxy = proxy;
     }
@@ -32,7 +34,7 @@ abstract class S3Callable<T> implements FileCallable<T> {
     protected synchronized TransferManager getTransferManager() {
         final String uniqueKey = getUniqueKey();
         if (transferManagers.get(uniqueKey) == null) {
-            final AmazonS3 client = ClientHelper.createClient(accessKey, Secret.toString(secretKey), useRole, region, proxy);
+            final AmazonS3 client = ClientHelper.createClient(accessKey, Secret.toString(secretKey), useRole, endpoint, region, proxy);
             transferManagers.put(uniqueKey, new TransferManager(client));
         }
 

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -16,9 +16,9 @@ public final class S3DownloadCallable extends S3Callable<String>
     private static final long serialVersionUID = 1L;
     private final Destination dest;
     
-    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, String region, ProxyConfiguration proxy)
+    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, String endpoint, Destination dest, String region, ProxyConfiguration proxy)
     {
-        super(accessKey, secretKey, useRole, region, proxy);
+        super(accessKey, secretKey, useRole, endpoint, region, proxy);
         this.dest = dest;
     }
 

--- a/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
@@ -17,8 +17,8 @@ import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 public final class S3GzipCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
-    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, String endpoint, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, endpoint, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
     }
 
     // Return a File containing the gzipped contents of the input file.

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -14,8 +14,8 @@ import java.util.Map;
 public final class S3UploadCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
     private static final long serialVersionUID = 1L;
 
-    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, String endpoint, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, endpoint, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
     }
 
     /**

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -14,7 +14,7 @@
           <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
             <f:textbox name="s3.accessKey" value="${profile.accessKey}"
                     checkMethod="post"
-                    checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)+'&amp;useRole='+encodeURIComponent(Form.findMatchingInput(this,'s3.useRole').value)"
+                    checkUrl="'${rootURL}/publisher/S3BucketPublisher/loginCheck?name='+encodeURIComponent(Form.findMatchingInput(this,'s3.name').value)+'&amp;secretKey='+encodeURIComponent(Form.findMatchingInput(this,'s3.secretKey').value)+'&amp;accessKey='+encodeURIComponent(this.value)+'&amp;useRole='+encodeURIComponent(Form.findMatchingInput(this,'s3.useRole').value)+'&amp;endpoint='+encodeURIComponent(Form.findMatchingInput(this,'s3.endpoint').value)"
             />
           </f:entry>
           <f:entry title="Secret key" help="/plugin/s3/help-secretkey.html">
@@ -24,6 +24,9 @@
             />
           </f:entry>
           <f:advanced>
+            <f:entry title="Endpoint URL" help="/plugin/s3/help-endpoint.html">
+              <f:textbox name="s3.endpoint" value="${profile.endpoint}" onchange="Form.findMatchingInput(this,'s3.accessKey').onchange()" />
+            </f:entry>
             <f:entry title="Max upload retries">
                 <f:number name="s3.maxUploadRetries" value="${profile.maxUploadRetries}"/>
             </f:entry>

--- a/src/main/webapp/help-endpoint.html
+++ b/src/main/webapp/help-endpoint.html
@@ -1,0 +1,1 @@
+<div>S3 Endpoint URL</div>

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -28,7 +28,9 @@ import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 
+
 public class S3Test {
+
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
@@ -40,7 +42,7 @@ public class S3Test {
 
     @Test
     public void testConfigContainsProfiles() throws Exception {
-        final S3Profile profile = new S3Profile("S3 profile random name", null, null, true, 0, "0", "0", "0", "0", true);
+        final S3Profile profile = new S3Profile("S3 profile random name", null, null, true, "", 0, "0", "0", "0", "0", true);
 
         replaceS3PluginProfile(profile);
 
@@ -97,6 +99,18 @@ public class S3Test {
 
         QueueTaskFuture<FreeStyleBuild> r = project.scheduleBuild2(0);
         j.assertBuildStatus(Result.FAILURE, r);
+    }
+
+    @Test
+    public void setEndpointTest() throws Exception {
+        String newEndpoint = "http://s3.example.com";
+        HtmlPage page = j.createWebClient().goTo("configure");
+        final S3Profile profile = new S3Profile("S3 profile random name", null, null, true, newEndpoint, 0, "0", "0", "0", "0", true);
+        WebAssert.assertTextNotPresent(page, newEndpoint);
+        replaceS3PluginProfile(profile);
+        page = j.createWebClient().goTo("configure");
+        WebAssert.assertTextPresent(page, newEndpoint);
+        assertEquals(newEndpoint, profile.getEndpoint());
     }
 
     private Entry entryForFile(String fileName) {


### PR DESCRIPTION
This would allow the ability to override/set the Endpoint URL for an S3Profile (useful for non-Amazon storage systems with S3 interfaces).  

To do this currently, it appears you must create a custom endpoints.json to override the defaults, and include it in the actual Jenkins classpath.  Allowing the endpoint to be set as a config field should be more a intuitive/maintainable process for this functionality.