### PR TITLE
Fix PCT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/s3-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/s3-plugin.git</developerConnection>
+        <connection>scm:git:git://github.com/jenkinsci/s3-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/s3-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/s3-plugin</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
PCT is not able to work properly because the 'connection' and 'developerConnection' fields use ssh as a protocol.