### PR TITLE
Revert try-with-resources for S3GzipCallable

### DIFF
--- a/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
@@ -71,7 +71,8 @@ public final class S3GzipCallable extends S3BaseUploadCallable implements Master
         final File localFile = gzipFile(file);
         Upload upload = null;
 
-        try (final InputStream gzippedStream = new FileInputStream(localFile)) {
+        try {
+            final InputStream gzippedStream = new FileInputStream(localFile)
             final ObjectMetadata metadata = buildMetadata(file);
             metadata.setContentEncoding("gzip");
             metadata.setContentLength(localFile.length());


### PR DESCRIPTION
This would close the InputStream prematurely, failing on the scheduled uploads who expected an open stream.

Note that as the upload continues after the return, therefore the zip-stream must not (yet) be closed in this context.

Fixes JENKINS-60916