### PR TITLE
Permit uploading artifacts for aborted builds

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -50,6 +50,11 @@ public final class Entry implements Describable<Entry> {
     public boolean noUploadOnFailure;
 
     /**
+     * Do not publish the artifacts when build is aborted
+     */
+    public boolean noUploadOnAborted;
+
+    /**
      * Upload either from the slave or the master
      */
     public boolean uploadFromSlave;
@@ -92,7 +97,7 @@ public final class Entry implements Describable<Entry> {
 
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String excludedFile, String storageClass, String selectedRegion,
-                 boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
+                 boolean noUploadOnFailure, boolean noUploadOnAborted, boolean uploadFromSlave, boolean managedArtifacts,
                  boolean useServerSideEncryption, boolean flatten, boolean gzipFiles, boolean keepForever,
                  boolean showDirectlyInBrowser, List<MetadataPair> userMetadata) {
         this.bucket = bucket;
@@ -101,6 +106,7 @@ public final class Entry implements Describable<Entry> {
         this.storageClass = storageClass;
         this.selectedRegion = selectedRegion;
         this.noUploadOnFailure = noUploadOnFailure;
+        this.noUploadOnAborted = noUploadOnAborted;
         this.uploadFromSlave = uploadFromSlave;
         this.managedArtifacts = managedArtifacts;
         this.useServerSideEncryption = useServerSideEncryption;

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -219,10 +219,6 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
         final PrintStream console = listener.getLogger();
-        if (Result.ABORTED.equals(run.getResult())) {
-            log(Level.SEVERE, console, "Skipping publishing on S3 because build aborted");
-            return;
-        }
 
         if (run.isBuilding()) {
             log(console, "Build is still running");
@@ -252,6 +248,12 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
                     log(Level.WARNING, console, "Skipping publishing on S3 because build failed");
                     continue;
                 }
+
+                if (entry.noUploadOnAborted && Result.ABORTED.equals(run.getResult())) {
+                    log(Level.SEVERE, console, "Skipping publishing on S3 because build aborted");
+                    return;
+                }
+
 
                 final String expanded = Util.replaceMacro(entry.sourceFile, envVars);
                 final String exclude = Util.replaceMacro(entry.excludedFile, envVars);

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -19,6 +19,9 @@
         <f:entry field="noUploadOnFailure" title="No upload on build failure">
 		    <f:checkbox />
         </f:entry>
+        <f:entry field="noUploadOnAborted" title="No upload on aborted build">
+            <f:checkbox />
+        </f:entry>
         <f:entry field="uploadFromSlave" title="Publish from Slave">
 		    <f:checkbox />
         </f:entry>

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -102,7 +102,7 @@ public class S3Test {
     }
 
     private Entry entryForFile(String fileName) {
-        return new Entry("bucket", fileName, "", "", "", false, false, true, false, false, false, false, false, null);
+        return new Entry("bucket", fileName, "", "", "", false, false, false, true, false, false, false, false, false, null);
     }
 
     private Builder stepCreatingFile(String fileName) {


### PR DESCRIPTION
Right now there is a configuration option for overriding the default behavior that prevents uploading artifacts when the build fails. However nonesuch option exists for overriding the same behavior preventing uploading artifacts for _aborted_ builds. 

This adds that option so that for aborted builds artifacts can be pushed to S3. 