### PR TITLE
fix: userRole value does not presented correctly, thus value might be

### DIFF
--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -9,7 +9,7 @@
             <f:textbox name="name" value="${profile.name}" />
           </f:entry>
           <f:entry title="Use IAM Role" help="/plugin/s3/help-role.html">
-            <f:checkbox name="useRole" value="${profile.useRole}" />
+            <f:checkbox name="useRole" default="false" checked="${profile.useRole}" />
           </f:entry>
           <f:entry title="Access key" help="/plugin/s3/help-accesskey.html">
             <f:textbox name="accessKey" value="${profile.accessKey}" />


### PR DESCRIPTION
changed unintentionally

Fix JENKINS-64524
If you are checking the useRole checkbox and save, later going in to the configuration screen will be shown as unchecked, if you save it now the value will change to uncheck.
This leads to confuse and  unintentionally change to this value.
The correct way of setting the checkbox value now is using the **checked** property.

It is better to follow this [answer](https://stackoverflow.com/a/23994984/7837926) in stackoverflow, still this fix is working just fine. 