### PR TITLE
[JENKINS-62907] Table to divs compatibility

### DIFF
--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -1,10 +1,10 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:s3="/lib/s3Plugin">
   <!-- nothing to configure -->
   <f:section title="Amazon S3 profiles">
     <f:entry title="S3 profiles" description="Profiles for publishing to S3 buckets">
       <f:repeatable var="profile" items="${descriptor.profiles}">
-        <table width="100%">
+        <s3:blockWrapper>
           <f:entry title="Profile name" help="/plugin/s3/help-profile.html">
             <f:textbox name="name" value="${profile.name}" />
           </f:entry>
@@ -48,7 +48,7 @@
             </div>
           </f:entry>
 
-        </table>
+        </s3:blockWrapper>
       </f:repeatable>
     </f:entry>
   </f:section>

--- a/src/main/resources/lib/s3Plugin/blockWrapper.jelly
+++ b/src/main/resources/lib/s3Plugin/blockWrapper.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
+  <!-- TODO remove and switch to div after baseline is 2.264 or newer -->
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div>
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <table width="100%" padding="0">
+        <d:invokeBody/>
+      </table>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>


### PR DESCRIPTION
This is to make sure the plugin stays operational with the Tables to divs initiative which landed in 2.264.

I didn't notice any problem with the configuration itself.

<details>
<summary>Before</summary>

![Screenshot from 2021-01-14 14-00-27](https://user-images.githubusercontent.com/985955/104594389-60c8d600-5671-11eb-991b-dfde4d51e72f.png)

</details>

<details>
<summary>After</summary>

![Screenshot from 2021-01-14 14-02-03](https://user-images.githubusercontent.com/985955/104594445-7211e280-5671-11eb-91f4-77ae98076157.png)

</details>
