### PR TITLE
Integrate SECURITY-2458 adaptation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <artifactId>s3</artifactId>
     <packaging>hpi</packaging>
-    <version>0.12.1</version>
+    <version>0.12.2-SNAPSHOT</version>
     <name>Jenkins S3 publisher plugin</name>
     <url>https://github.com/jenkinsci/s3-plugin</url>
 
@@ -52,7 +52,7 @@
         <connection>scm:git:git://github.com/jenkinsci/s3-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/s3-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/s3-plugin</url>
-        <tag>s3-0.12.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <artifactId>s3</artifactId>
     <packaging>hpi</packaging>
-    <version>0.12.1-SNAPSHOT</version>
+    <version>0.12.1</version>
     <name>Jenkins S3 publisher plugin</name>
     <url>https://github.com/jenkinsci/s3-plugin</url>
 
@@ -52,7 +52,7 @@
         <connection>scm:git:git://github.com/jenkinsci/s3-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/s3-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/s3-plugin</url>
-        <tag>HEAD</tag>
+        <tag>s3-0.12.1</tag>
     </scm>
 
     <dependencies>

--- a/src/main/java/hudson/plugins/s3/callable/S3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3Callable.java
@@ -7,6 +7,7 @@ import hudson.FilePath.FileCallable;
 import hudson.ProxyConfiguration;
 import hudson.plugins.s3.ClientHelper;
 import hudson.util.Secret;
+import jenkins.security.Roles;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.remoting.RoleChecker;
 
@@ -46,7 +47,7 @@ abstract class S3Callable<T> implements FileCallable<T> {
 
     @Override
     public void checkRoles(RoleChecker roleChecker) throws SecurityException {
-
+        roleChecker.check(this, Roles.SLAVE);
     }
 
     private String getUniqueKey() {

--- a/src/main/java/hudson/plugins/s3/callable/S3CleanupUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3CleanupUploadCallable.java
@@ -3,6 +3,7 @@ package hudson.plugins.s3.callable;
 import hudson.FilePath;
 import hudson.plugins.s3.Uploads;
 import hudson.remoting.VirtualChannel;
+import jenkins.security.Roles;
 import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
@@ -22,6 +23,6 @@ public final class S3CleanupUploadCallable implements MasterSlaveCallable<Void> 
 
     @Override
     public void checkRoles(RoleChecker checker) throws SecurityException {
-
+        checker.check(this, Roles.SLAVE);
     }
 }

--- a/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
@@ -3,6 +3,7 @@ package hudson.plugins.s3.callable;
 import hudson.FilePath;
 import hudson.plugins.s3.Uploads;
 import hudson.remoting.VirtualChannel;
+import jenkins.security.Roles;
 import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
@@ -22,6 +23,6 @@ public final class S3WaitUploadCallable implements MasterSlaveCallable<Void> {
 
     @Override
     public void checkRoles(RoleChecker checker) throws SecurityException {
-
+        checker.check(this, Roles.SLAVE);
     }
 }


### PR DESCRIPTION
Should be merged using merge-commit, not squash-merge or rebase-merge, to ensure https://github.com/jenkinsci/s3-plugin/releases/tag/s3-0.12.1 is in the history of the default branch.