### PR TITLE
Prepare for sunset icon removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/s3/S3ArtifactsAction/index.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3ArtifactsAction/index.jelly
@@ -4,7 +4,7 @@
     <st:include it="${it.build}" page="sidepanel.jelly" />
     <l:main-panel>
       <h1>
-        <img src="${imagesURL}/48x48/fingerprint.png" alt="" height="48" width="48"/>
+        <l:icon class="icon-fingerprint icon-xlg" alt=""/>
         S3 Artifacts
       </h1>
       <table class="fingerprint-in-build sortable bigtable">
@@ -19,7 +19,7 @@
             </td>
             <td>
               <a href="${rootURL}/fingerprint/${e.fingerprint}/">
-                <img src="${imagesURL}/16x16/fingerprint.png" alt="" height="16" width="16"/> ${%more details}
+                <l:icon class="icon-fingerprint icon-sm" alt=""/> ${%more details}
               </a>
             </td>
           </tr>

--- a/src/main/resources/hudson/plugins/s3/S3ArtifactsProjectAction/jobMain.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3ArtifactsProjectAction/jobMain.jelly
@@ -4,7 +4,7 @@
   <j:set var="latestDeployedArtifacts" value="${it.latestDeployedArtifacts}"/>
   <j:if test="${latestDeployedArtifacts != null}">
       <table style="margin-top: 1em; margin-left:1em;">
-        <t:summary icon="package.gif">
+        <t:summary icon="package.png">
             ${%Last Successful Deployed Artifacts}
             <ul>
                <j:set var="lastSuccessfulNumber" value="${it.lastSuccessfulNumber}"/>


### PR DESCRIPTION
Preparation for core sunsetting dated icons: https://github.com/jenkinsci/jenkins/pull/5778

@rsandell Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!