### PR TITLE
[JENKINS-69578] Java serialization error when saving Jenkins project containing S3 publisher plugin

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -66,7 +66,20 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     private boolean dontWaitForConcurrentBuildCompletion;
     private boolean dontSetBuildResultOnFailure;
 
-    private Level consoleLogLevel;
+    /**
+     * In-memory representation of console log level.
+     *
+     * @see #consoleLogLevelString
+     */
+    private transient Level consoleLogLevel;
+
+    /**
+     * Serial form of console log level.
+     *
+     * @see #consoleLogLevel
+     */
+    private String consoleLogLevelString;
+
     private Result pluginFailureResultConstraint;
     /**
      * User metadata key/value pairs to tag the upload with.
@@ -95,6 +108,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         this.dontWaitForConcurrentBuildCompletion = dontWaitForConcurrentBuildCompletion;
         this.dontSetBuildResultOnFailure = dontSetBuildResultOnFailure;
         this.consoleLogLevel = parseLevel(consoleLogLevel);
+        this.consoleLogLevelString = this.consoleLogLevel.getName();
         if (pluginFailureResultConstraint == null) {
             this.pluginFailureResultConstraint = Result.FAILURE;
         } else {
@@ -119,8 +133,16 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         if (pluginFailureResultConstraint == null)
             pluginFailureResultConstraint = Result.FAILURE;
 
+        if (consoleLogLevel != null && consoleLogLevelString == null) {
+            consoleLogLevelString = consoleLogLevel.getName();
+        }
+
         if(consoleLogLevel==null)
             consoleLogLevel = Level.INFO;
+
+        if (consoleLogLevelString == null) {
+            consoleLogLevelString = consoleLogLevel.getName();
+        }
 
         return this;
     }
@@ -182,7 +204,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
      */
     @SuppressWarnings("unused")
     public String getConsoleLogLevel() {
-        return consoleLogLevel.toString();
+        return consoleLogLevelString;
     }
 
     public S3Profile getProfile() {

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -137,6 +137,10 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
             consoleLogLevelString = consoleLogLevel.getName();
         }
 
+        if (consoleLogLevel == null && consoleLogLevelString != null) {
+            consoleLogLevel = parseLevel(consoleLogLevelString);
+        }
+
         if(consoleLogLevel==null)
             consoleLogLevel = Level.INFO;
 


### PR DESCRIPTION
See [JENKINS-69578](https://issues.jenkins.io/browse/JENKINS-69578). Resolves an issue running on Java 17, which can no longer serialize `java.util.logging.Level` objects due to the `java.util.logging` package not being accessible to XStream. I solved the issue by instead serializing the name of the level:

```
-      <consoleLogLevel>
-        <name>INFO</name>
-        <value>800</value>
-        <resourceBundleName>sun.util.logging.resources.logging</resourceBundleName>
-      </consoleLogLevel>
+      <consoleLogLevelString>INFO</consoleLogLevelString>
```

This PR implements a `readResolve` method to allow old data to be converted to the new format (when running under Java 11 or Java 8 where this bug does not occur). I added the `transient` keyword to the old field name to prevent it from being serialized to disk once it has been read for migration purposes, as recommended in [the documentation](https://www.jenkins.io/doc/developer/persistence/backward-compatibility/).

To test this, I successfully created data using the old version of the plugin with Java 11 and verified that the new version of the plugin with the changes from this PR running on Java 17 could parse the old data and write it out in the new format. I also verified that the steps to reproduce described in the Jira ticket failed before this PR on Java 17 and passed after this PR on Java 17.

CC @rsandell @jtnord @alecharp as the last few people to work on this plugin