### PR TITLE
JENKINS-70032 : Make maven-plugin an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
             <version>3.16</version>
+            <optional>true</optional>
             <exclusions>
                 <exclusion>
                     <groupId>commons-io</groupId>

--- a/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
+++ b/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
@@ -217,7 +217,7 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
 
             excludeFilter = env.expand(excludeFilter);
 
-            if (src instanceof MavenModuleSetBuild) {
+            if (Jenkins.getInstanceOrNull().getPlugin("maven-plugin") != null && src instanceof MavenModuleSetBuild) {
                 // Copy artifacts from the build (ArchiveArtifacts build step)
                 boolean ok = perform(src, dst, includeFilter, excludeFilter, targetDir, console);
 
@@ -335,12 +335,13 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
             final FormValidation result;
             final Item item = new JobResolver(value).job;
             if (item != null) {
-                
-                result = item instanceof MavenModuleSet
-                       ? FormValidation.warning(Messages.CopyArtifact_MavenProject())
-                        : (item instanceof MatrixProject
-                        ? FormValidation.warning(Messages.CopyArtifact_MatrixProject())
-                        : FormValidation.ok());
+                if (Jenkins.getInstanceOrNull().getPlugin("maven-plugin") != null && item instanceof MavenModuleSet) {
+                    result = FormValidation.warning(Messages.CopyArtifact_MavenProject());
+                } else {
+                    result = (item instanceof MatrixProject)
+                          ? FormValidation.warning(Messages.CopyArtifact_MatrixProject())
+                          : FormValidation.ok();
+                }
             }
             else if (value.indexOf('$') >= 0) {
                 result = FormValidation.warning(Messages.CopyArtifact_ParameterizedName());

--- a/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
+++ b/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
@@ -161,6 +161,11 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
         else
             run.setResult(Result.FAILURE);
     }
+    
+    private static boolean isMavenPluginInstalled() {
+      Jenkins instance = Jenkins.getInstanceOrNull();
+      return instance != null && instance.getPlugin("maven-plugin") != null;
+    }
 
     @Override
     public void perform(@Nonnull Run<?, ?> dst, @Nonnull FilePath targetDir, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
@@ -217,7 +222,7 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
 
             excludeFilter = env.expand(excludeFilter);
 
-            if (Jenkins.getInstanceOrNull().getPlugin("maven-plugin") != null && src instanceof MavenModuleSetBuild) {
+            if (isMavenPluginInstalled() && src instanceof MavenModuleSetBuild) {
                 // Copy artifacts from the build (ArchiveArtifacts build step)
                 boolean ok = perform(src, dst, includeFilter, excludeFilter, targetDir, console);
 
@@ -335,7 +340,7 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
             final FormValidation result;
             final Item item = new JobResolver(value).job;
             if (item != null) {
-                if (Jenkins.getInstanceOrNull().getPlugin("maven-plugin") != null && item instanceof MavenModuleSet) {
+                if (isMavenPluginInstalled() && item instanceof MavenModuleSet) {
                     result = FormValidation.warning(Messages.CopyArtifact_MavenProject());
                 } else {
                     result = (item instanceof MatrixProject)


### PR DESCRIPTION
This change makes maven-plugin an optional dependency, for the reasons explained in [JENKINS-70032](https://issues.jenkins.io/browse/JENKINS-70032).

The copy artifact plugin already does this, so I just copied its plugin checks:

https://github.com/jenkinsci/copyartifact-plugin/blob/master/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L525

https://github.com/jenkinsci/copyartifact-plugin/blob/master/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L848

cc @alecharp since you last committed to the repo.