### PR TITLE
Test with Java 21 and Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
-// Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin(configurations: [
-  [ platform: 'linux', jdk: '11' ],
-  [ platform: 'windows', jdk: '11' ],
-  [ platform: 'linux', jdk: '17' ],
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useContainerAgent: false, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],
     [platform: 'windows', jdk: 17],

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.76</version>
+        <version>4.80</version>
     </parent>
 
     <artifactId>s3</artifactId>


### PR DESCRIPTION
## Test with Java 21 and Java 17

Java 21 released Sep 19, 2023. Full support for Java 21 in Jenkins was announced in November 2023.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.  Prepares for the Oct 2024 end of life of Java 11.

This does not test Java 11 because the Java 17 build and the Java 21 build are both generating Java 11 byte code.  We've detected no issues related to building Java 11 byte code with Java 17 and Java 21.

This is one of the last plugins in the top 250 most popular plugins to not yet test with Java 17 and Java 21.

Includes or supersedes the following pull requests:

* #273
* #275
* #276

### Testing done

Confirmed that tests pass with Java 21 on Red Hat Enterprise Linux 8 and Ubuntu 22.04.  Confirmed that tests pass with Java 17 on Red Hat Enterprise Linux 8.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
