### PR TITLE
Fix JSR-305 annotations

### DIFF
--- a/src/main/java/hudson/plugins/s3/ClientHelper.java
+++ b/src/main/java/hudson/plugins/s3/ClientHelper.java
@@ -9,14 +9,14 @@ import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.ProxyConfiguration;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public class ClientHelper {
     public final static String DEFAULT_AMAZON_S3_REGION_NAME = System.getProperty(
@@ -56,7 +56,7 @@ public class ClientHelper {
      * @param regionName nullable region name
      * @return AWS region, never {@code null}, defaults to {@link com.amazonaws.services.s3.model.Region#US_Standard}
      */
-    @Nonnull
+    @NonNull
     private static Region getRegionFromString(@Nullable String regionName) {
         Region region = null;
 
@@ -83,8 +83,8 @@ public class ClientHelper {
         return region;
     }
 
-    @Nonnull
-    public static ClientConfiguration getClientConfiguration(@Nonnull ProxyConfiguration proxy, @Nonnull Region region) {
+    @NonNull
+    public static ClientConfiguration getClientConfiguration(@NonNull ProxyConfiguration proxy, @NonNull Region region) {
         final ClientConfiguration clientConfiguration = new ClientConfiguration();
         String s3Endpoint;
         if (StringUtils.isNotEmpty(ENDPOINT)) {

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -43,7 +43,6 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -151,7 +150,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         return this;
     }
 
-    private Result constrainResult(Result r, @Nonnull TaskListener listener) {
+    private Result constrainResult(Result r, @NonNull TaskListener listener) {
         final PrintStream console = listener.getLogger();
         // pass through NOT_BUILT and ABORTED
         if (r.isWorseThan(Result.FAILURE)) {
@@ -246,7 +245,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath ws, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath ws, @NonNull Launcher launcher, @NonNull TaskListener listener)
             throws InterruptedException, IOException {
         final PrintStream console = listener.getLogger();
         if (Result.ABORTED.equals(run.getResult())) {
@@ -368,7 +367,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         }
     }
 
-    private void printDiagnostics(@Nonnull FilePath ws, PrintStream console, String expanded) throws IOException {
+    private void printDiagnostics(@NonNull FilePath ws, PrintStream console, String expanded) throws IOException {
         log(Level.WARNING, console, "No file(s) found: " + expanded);
         try {
             final String error = ws.validateAntFileMask(expanded, 100);
@@ -383,7 +382,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     }
 
     @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
-    private void fillFingerprints(@Nonnull Run<?, ?> run, @Nonnull TaskListener listener, Map<String, String> record, List<FingerprintRecord> fingerprints) throws IOException {
+    private void fillFingerprints(@NonNull Run<?, ?> run, @NonNull TaskListener listener, Map<String, String> record, List<FingerprintRecord> fingerprints) throws IOException {
         for (FingerprintRecord r : fingerprints) {
             final Fingerprint fp = r.addRecord(run);
             if (fp == null) {

--- a/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
+++ b/src/main/java/hudson/plugins/s3/S3CopyArtifact.java
@@ -24,6 +24,7 @@
 package hudson.plugins.s3;
 
 import com.google.common.collect.Maps;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -82,8 +83,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-
-import javax.annotation.Nonnull;
 
 /**
  * This is a S3 variant of the CopyArtifact plugin:
@@ -151,7 +150,7 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
         return optional != null && optional;
     }
 
-    private void setResult(@Nonnull Run<?, ?> run, boolean isOk) {
+    private void setResult(@NonNull Run<?, ?> run, boolean isOk) {
         if (isOptional()) {
             return;
         }
@@ -168,7 +167,7 @@ public class S3CopyArtifact extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> dst, @Nonnull FilePath targetDir, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(@NonNull Run<?, ?> dst, @NonNull FilePath targetDir, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         final PrintStream console = listener.getLogger();
         String expandedProject = projectName;
         String includeFilter = getFilter();


### PR DESCRIPTION
## Fix JSR-305 annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java. Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

Refer to the mailing list discussion from James Nord at https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ .

### Testing done

Confirmed that code compiles and automated tests pass.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
