### PR TITLE
Make dep on `matrix-project` optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
-            <version>3.23</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -91,6 +90,11 @@
                     <artifactId>commons-io</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Analogue of https://github.com/jenkinsci/copyartifact-plugin/pull/234, and required by it (otherwise PCT fails in `MinIOTest.testS3CopyArtifact` with a `NoClassDefFoundError` since the `matrix-project` dep was implicit).