### PR TITLE
Add supporting S3 tags

### DIFF
--- a/src/main/java/hudson/plugins/s3/Entry.java
+++ b/src/main/java/hudson/plugins/s3/Entry.java
@@ -90,11 +90,16 @@ public final class Entry implements Describable<Entry> {
     */
     public List<MetadataPair> userMetadata;
 
+    /**
+     * Tags overrides
+     */
+    public List<TagPair> userTags;
+
     @DataBoundConstructor
     public Entry(String bucket, String sourceFile, String excludedFile, String storageClass, String selectedRegion,
                  boolean noUploadOnFailure, boolean uploadFromSlave, boolean managedArtifacts,
                  boolean useServerSideEncryption, boolean flatten, boolean gzipFiles, boolean keepForever,
-                 boolean showDirectlyInBrowser, List<MetadataPair> userMetadata) {
+                 boolean showDirectlyInBrowser, List<MetadataPair> userMetadata, List<TagPair> userTags) {
         this.bucket = bucket;
         this.sourceFile = sourceFile;
         this.excludedFile = excludedFile;
@@ -108,6 +113,7 @@ public final class Entry implements Describable<Entry> {
         this.gzipFiles = gzipFiles;
         this.keepForever = keepForever;
         this.userMetadata = userMetadata;
+        this.userTags = userTags;
         this.showDirectlyInBrowser = showDirectlyInBrowser;
     }
 

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -126,6 +126,7 @@ public class S3Profile {
                                     final List<FilePath> filePaths,
                                     final List<String> fileNames,
                                     final Map<String, String> userMetadata,
+                                    final Map<String, String> userTags,
                                     final String storageClass,
                                     final String selregion,
                                     final boolean uploadFromSlave,
@@ -151,10 +152,10 @@ public class S3Profile {
 
                 final MasterSlaveCallable<String> upload;
                 if (gzipFiles) {
-                    upload = new S3GzipCallable(accessKey, secretKey, useRole, dest, userMetadata,
+                    upload = new S3GzipCallable(accessKey, secretKey, useRole, dest, userMetadata, userTags,
                             storageClass, selregion, useServerSideEncryption, getProxy());
                 } else {
-                    upload = new S3UploadCallable(accessKey, secretKey, useRole, dest, userMetadata,
+                    upload = new S3UploadCallable(accessKey, secretKey, useRole, dest, userMetadata, userTags,
                             storageClass, selregion, useServerSideEncryption, getProxy());
                 }
 

--- a/src/main/java/hudson/plugins/s3/TagPair.java
+++ b/src/main/java/hudson/plugins/s3/TagPair.java
@@ -1,0 +1,43 @@
+package hudson.plugins.s3;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public final class TagPair implements Describable<TagPair> {
+
+    /**
+     * The key of the user tag pair to tag an upload with.
+     * Can contain macros.
+     */
+    public String key;
+
+    /**
+     * The key of the user tag pair to tag an upload with.
+     * Can contain macros.
+     */
+    public String value;
+
+    @DataBoundConstructor
+    public TagPair(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public Descriptor<TagPair> getDescriptor() {
+        return DESCRIPOR;
+    }
+
+    @Extension
+    public final static DescriptorImpl DESCRIPOR = new DescriptorImpl();
+
+    public static class DescriptorImpl extends Descriptor<TagPair> {
+
+        @Override
+        public String getDisplayName() {
+            return "Tag";
+        }
+    };
+}
+

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -2,6 +2,7 @@ package hudson.plugins.s3;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
@@ -21,8 +22,8 @@ public final class Uploads {
     private final transient HashMap<FilePath, Upload> startedUploads = new HashMap<>();
     private final transient HashMap<FilePath, InputStream> openedStreams = new HashMap<>();
 
-    public Upload startUploading(TransferManager manager, FilePath file, InputStream inputsStream, String bucketName, String objectName, ObjectMetadata metadata) throws AmazonServiceException {
-        final PutObjectRequest request = new PutObjectRequest(bucketName, objectName, inputsStream, metadata);
+    public Upload startUploading(TransferManager manager, FilePath file, InputStream inputsStream, String bucketName, String objectName, ObjectMetadata metadata, ObjectTagging tags) throws AmazonServiceException {
+        final PutObjectRequest request = new PutObjectRequest(bucketName, objectName, inputsStream, metadata).withTagging(tags);
 
         // Set the buffer size (ReadLimit) equal to the multipart upload size,
         // allowing us to resend data if the connection breaks.

--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -2,6 +2,8 @@ package hudson.plugins.s3.callable;
 
 import com.amazonaws.services.s3.internal.Mimetypes;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
+import com.amazonaws.services.s3.model.Tag;
 import hudson.FilePath;
 import hudson.ProxyConfiguration;
 import hudson.plugins.s3.Destination;
@@ -12,24 +14,28 @@ import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public abstract class S3BaseUploadCallable extends S3Callable<String> {
     private static final long serialVersionUID = 1L;
     private final Destination dest;
     private final String storageClass;
     private final Map<String, String> userMetadata;
+    private final Map<String, String> userTags;
     private final boolean useServerSideEncryption;
 
-
     public S3BaseUploadCallable(String accessKey, Secret secretKey, boolean useRole,
-                                Destination dest, Map<String, String> userMetadata, String storageClass, String selregion,
-                                boolean useServerSideEncryption, ProxyConfiguration proxy) {
+                                Destination dest, Map<String, String> userMetadata, Map<String, String> userTags,
+                                String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
         super(accessKey, secretKey, useRole, selregion, proxy);
         this.dest = dest;
         this.storageClass = storageClass;
         this.userMetadata = userMetadata;
+        this.userTags = userTags;
         this.useServerSideEncryption = useServerSideEncryption;
     }
 
@@ -84,6 +90,15 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
             }
         }
         return metadata;
+    }
+
+    protected ObjectTagging s3Tagging() {
+
+        final List<Tag> tags = userTags.entrySet().stream()
+                .map(entry -> new Tag(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+
+        return new ObjectTagging(tags);
     }
 
     public Destination getDest() {

--- a/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
@@ -1,6 +1,7 @@
 package hudson.plugins.s3.callable;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.event.ProgressListener;
 import com.amazonaws.event.ProgressEvent;
@@ -23,8 +24,8 @@ import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 public final class S3GzipCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
-    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, Map<String, String> userTags, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, dest, userMetadata, userTags, storageClass, selregion, useServerSideEncryption, proxy);
     }
 
     // Return a File containing the gzipped contents of the input file.
@@ -78,10 +79,11 @@ public final class S3GzipCallable extends S3BaseUploadCallable implements Master
             // close the stream before the upload has succeeded.
             final InputStream gzippedStream = new FileInputStream(localFile);
             final ObjectMetadata metadata = buildMetadata(file);
+            final ObjectTagging tags = s3Tagging();
             metadata.setContentEncoding("gzip");
             metadata.setContentLength(localFile.length());
 
-            upload = Uploads.getInstance().startUploading(getTransferManager(), file, gzippedStream, getDest().bucketName, getDest().objectName, metadata);
+            upload = Uploads.getInstance().startUploading(getTransferManager(), file, gzippedStream, getDest().bucketName, getDest().objectName, metadata, tags);
 
             String md5 = MD5.generateFromFile(localFile);
 

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -1,6 +1,7 @@
 package hudson.plugins.s3.callable;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
 import hudson.FilePath;
 import hudson.ProxyConfiguration;
 import hudson.plugins.s3.Destination;
@@ -14,8 +15,8 @@ import java.util.Map;
 public final class S3UploadCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
     private static final long serialVersionUID = 1L;
 
-    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, Map<String, String> userTags, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
+        super(accessKey, secretKey, useRole, dest, userMetadata, userTags, storageClass, selregion, useServerSideEncryption, proxy);
     }
 
     /**
@@ -24,9 +25,11 @@ public final class S3UploadCallable extends S3BaseUploadCallable implements Mast
     @Override
     public String invoke(FilePath file) throws IOException, InterruptedException {
         final ObjectMetadata metadata = buildMetadata(file);
+        final ObjectTagging tags = s3Tagging();
 
-        Uploads.getInstance().startUploading(getTransferManager(), file, file.read(), getDest().bucketName, getDest().objectName, metadata);
+        Uploads.getInstance().startUploading(getTransferManager(), file, file.read(), getDest().bucketName, getDest().objectName, metadata, tags);
 
         return MD5.generateFromFile(file);
     }
+
 }

--- a/src/main/resources/hudson/plugins/s3/Entry/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/Entry/config.jelly
@@ -49,5 +49,14 @@
                 </f:entry>
             </f:repeatableProperty>
         </f:entry>
+        <f:entry title="Object tags">
+            <f:repeatableProperty field="userTags">
+                <f:entry title="">
+                    <div align="right">
+                        <f:repeatableDeleteButton />
+                    </div>
+                </f:entry>
+            </f:repeatableProperty>
+        </f:entry>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/config.jelly
@@ -26,6 +26,16 @@
     </f:repeatableProperty>
   </f:entry>
 
+  <f:entry title="Object tags">
+    <f:repeatableProperty field="userTags">
+      <f:entry title="">
+        <div align="right">
+          <f:repeatableDeleteButton />
+        </div>
+      </f:entry>
+    </f:repeatableProperty>
+  </f:entry>
+
   <f:entry title="Publish Failure Result Constraint" field="pluginFailureResultConstraint">
     <f:select />
   </f:entry>

--- a/src/main/resources/hudson/plugins/s3/TagPair/config.jelly
+++ b/src/main/resources/hudson/plugins/s3/TagPair/config.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+
+    <f:entry title="Tag key" field="key">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="Tag value" field="value">
+        <f:textbox />
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/hudson/plugins/s3/TagPair/help-key.html
+++ b/src/main/resources/hudson/plugins/s3/TagPair/help-key.html
@@ -1,0 +1,4 @@
+<div>
+    Tag key for the files from this build. Can contain macros (e.g. environment
+    variables).
+</div>

--- a/src/main/resources/hudson/plugins/s3/TagPair/help-value.html
+++ b/src/main/resources/hudson/plugins/s3/TagPair/help-value.html
@@ -1,0 +1,4 @@
+<div>
+    Tag value for the files from this build. Can contain macros (e.g.
+    environment variables).
+</div>

--- a/src/test/java/hudson/plugins/s3/MinIOTest.java
+++ b/src/test/java/hudson/plugins/s3/MinIOTest.java
@@ -146,11 +146,14 @@ public class MinIOTest {
                         false,
                         true,
                         false,
+                        Collections.emptyList(),
                         Collections.emptyList())),
+                Collections.emptyList(),
                 Collections.emptyList(),
                 true,
                 "FINE",
-                null, false));
+                null,
+                false));
         r.buildAndAssertSuccess(job);
     }
 

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -58,6 +58,7 @@ public class S3Test {
                 profileName,
                 newArrayList(entryForFile(fileName)),
                 Collections.<MetadataPair>emptyList(),
+                Collections.<TagPair>emptyList(),
                 true,
                 "INFO",
                 "SUCCESS",
@@ -85,6 +86,7 @@ public class S3Test {
                 missingProfileName,
                 newArrayList(entryForFile(fileName)),
                 Collections.<MetadataPair>emptyList(),
+                Collections.<TagPair>emptyList(),
                 true,
                 "DEBUG",
                 "SUCCESS",
@@ -102,7 +104,7 @@ public class S3Test {
     }
 
     private Entry entryForFile(String fileName) {
-        return new Entry("bucket", fileName, "", "", "", false, false, true, false, false, false, false, false, null);
+        return new Entry("bucket", fileName, "", "", "", false, false, true, false, false, false, false, false, null, null);
     }
 
     private Builder stepCreatingFile(String fileName) {
@@ -128,6 +130,7 @@ public class S3Test {
                 Mockito.anyString(),
                 Mockito.anyList(),
                 Mockito.anyList(),
+                Mockito.anyMap(),
                 Mockito.anyMap(),
                 Mockito.anyString(),
                 Mockito.anyString(),


### PR DESCRIPTION
The PR is adding supporting of S3 tags - https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html

Like S3 Metadata, S3 Tags is an optional list of key-values pairs which can be applied per object.

In our use-case with the s3-plugin + MinIO and we use special lifecycle polices which delete only the objects with a specific tag assigned.

To be able to test the plugin locally I had also to increase the version of jenkins to `2.414.3`.