### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/hudson/plugins/s3/BucketnameTest.java
+++ b/src/test/java/hudson/plugins/s3/BucketnameTest.java
@@ -1,36 +1,35 @@
 package hudson.plugins.s3;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BucketnameTest {
+class BucketnameTest {
 
-  @Test
-  public void testAnythingAfterSlashInBucketNameIsPrependedToObjectName() {
+    @Test
+    void testAnythingAfterSlashInBucketNameIsPrependedToObjectName() {
+        // Assertions based on the behaviour of toString is maybe fragile but I think
+        // reasonably readable.
 
-    // Assertions based on the behaviour of toString is maybe fragile but I think 
-    // reasonably readable.
-    
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=test.txt]", 
-        new Destination("my-bucket-name", "test.txt").toString() );
-    
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=foo/test.txt]", 
-        new Destination("my-bucket-name/foo", "test.txt").toString() );
-    
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=foo/baz/test.txt]", 
-        new Destination("my-bucket-name/foo/baz", "test.txt").toString() );
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=test.txt]",
+                new Destination("my-bucket-name", "test.txt").toString());
 
-    // Unclear if this is the desired behaviour or not:
-    assertEquals( "Destination [bucketName=my-bucket-name, objectName=/test.txt]", 
-        new Destination("my-bucket-name/", "test.txt").toString() );
-  
-  }
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=foo/test.txt]",
+                new Destination("my-bucket-name/foo", "test.txt").toString());
 
-  @Test
-  public void testWindowsPathsConvertingToS3CompatiblePaths() {
-    assertEquals("Destination [bucketName=my-bucket, objectName=with-some/subfolder//path-from/windows.txt]",
-            new Destination("my-bucket/with-some/subfolder/", "path-from\\windows.txt").toString() );
-  }
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=foo/baz/test.txt]",
+                new Destination("my-bucket-name/foo/baz", "test.txt").toString());
+
+        // Unclear if this is the desired behaviour or not:
+        assertEquals("Destination [bucketName=my-bucket-name, objectName=/test.txt]",
+                new Destination("my-bucket-name/", "test.txt").toString());
+
+    }
+
+    @Test
+    void testWindowsPathsConvertingToS3CompatiblePaths() {
+        assertEquals("Destination [bucketName=my-bucket, objectName=with-some/subfolder//path-from/windows.txt]",
+                new Destination("my-bucket/with-some/subfolder/", "path-from\\windows.txt").toString());
+    }
 
 }

--- a/src/test/java/hudson/plugins/s3/FileHelperTest.java
+++ b/src/test/java/hudson/plugins/s3/FileHelperTest.java
@@ -1,14 +1,15 @@
 package hudson.plugins.s3;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class FileHelperTest {
+class FileHelperTest {
+
     @Test
-    public void testSelectedWithAsterisk() throws Exception {
+    void testSelectedWithAsterisk() throws Exception {
         String includeFilter = "*";
         String excludeFilter = "b.txt";
 
@@ -17,7 +18,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testSelectedSimpleCase() throws Exception {
+    void testSelectedSimpleCase() throws Exception {
         String includeFilter = "a.txt, c.txt";
         String excludeFilter = "b.txt, d.txt";
 
@@ -29,7 +30,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testSelectedComplexCase() throws Exception {
+    void testSelectedComplexCase() throws Exception {
         String includeFilter = "a*.txt, c.txt";
         String excludeFilter = "*b.txt, d.txt";
 
@@ -43,7 +44,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testSelectedWithEmptyExcludeFilter() throws Exception {
+    void testSelectedWithEmptyExcludeFilter() throws Exception {
         String includeFilter = "a.txt";
         String excludeFilter = "";
 
@@ -52,7 +53,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testSelectedWithEmptyIncludeFilter() throws Exception {
+    void testSelectedWithEmptyIncludeFilter() throws Exception {
         String includeFilter = "";
         String excludeFilter = "b.txt";
 
@@ -61,21 +62,21 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testSelectedWithNullIncludeFilter() throws Exception {
+    void testSelectedWithNullIncludeFilter() throws Exception {
         String excludeFilter = "";
 
         assertFalse(FileHelper.selected(null, excludeFilter, "a.txt"));
     }
 
     @Test
-    public void testSelectedWithNullExcludeFilter() throws Exception {
+    void testSelectedWithNullExcludeFilter() throws Exception {
         String includeFilter = "a.txt";
 
         assertTrue(FileHelper.selected(includeFilter, null, "a.txt"));
     }
 
     @Test
-    public void testGetStartIndexWithAsterisk() throws Exception {
+    void testGetStartIndexWithAsterisk() throws Exception {
         String workspace = "/var/lib/jenkins/jobs/workspace";
         String folder = "tests/*";
 
@@ -84,7 +85,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testGetStartIndexWithAsteriskInside() throws Exception {
+    void testGetStartIndexWithAsteriskInside() throws Exception {
         final String workspace = "/var/lib/jenkins/jobs/workspace";
         final String folder = "tests/*/folder";
 
@@ -95,7 +96,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testGetStartIndexWithoutAsterisk() throws Exception {
+    void testGetStartIndexWithoutAsterisk() throws Exception {
         String workspace = "/var/lib/jenkins/jobs/workspace";
         String folder = "tests/";
 
@@ -106,7 +107,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testGetStartIndexWithAsteriskButKeepStructure() throws Exception {
+    void testGetStartIndexWithAsteriskButKeepStructure() throws Exception {
         String workspace = "/var/lib/jenkins/jobs/workspace";
         String folder = "tests/*";
 
@@ -117,7 +118,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testGetStartIndexWithAsteriskInTheMiddle() throws Exception {
+    void testGetStartIndexWithAsteriskInTheMiddle() throws Exception {
         String workspace = "/var/lib/jenkins/jobs/workspace";
         String folder = "tests/some_name.*.0.extension";
 
@@ -128,7 +129,7 @@ public class FileHelperTest {
     }
 
     @Test
-    public void testGetStartIndexWithAsteriskInsideButKeepStructure() throws Exception {
+    void testGetStartIndexWithAsteriskInsideButKeepStructure() throws Exception {
         String workspace = "/var/lib/jenkins/jobs/workspace";
         String folder = "tests/*/folder";
 

--- a/src/test/java/hudson/plugins/s3/FingerprintRecordTest.java
+++ b/src/test/java/hudson/plugins/s3/FingerprintRecordTest.java
@@ -1,28 +1,29 @@
 package hudson.plugins.s3;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-public class FingerprintRecordTest {
+class FingerprintRecordTest {
 
     @Test
-    public void testGetLinkFromWindowsPath() throws Exception {
+    void testGetLinkFromWindowsPath() throws Exception {
         String windowsPath = "path\\to\\windows\\test.txt";
         FingerprintRecord windowsRecord = new FingerprintRecord(true, "test", windowsPath, "us-eat-1", "xxxx");
         String link = windowsRecord.getLink();
-        String linkDecoded = URLDecoder.decode(link, "utf-8");
-        assertNotEquals("link is encoded", windowsPath, link);
-        assertEquals("should match file name", windowsPath, linkDecoded);
+        String linkDecoded = URLDecoder.decode(link, StandardCharsets.UTF_8);
+        assertNotEquals(windowsPath, link, "link is encoded");
+        assertEquals(windowsPath, linkDecoded, "should match file name");
     }
 
     @Test
-    public void testGetLinkFromUnixPath() throws Exception {
+    void testGetLinkFromUnixPath() throws Exception {
         String unixPath = "/path/tmp/abc";
         FingerprintRecord unixRecord = new FingerprintRecord(true, "test", unixPath, "us-eat-1", "xxxx");
-        assertEquals("should match file name", unixPath, unixRecord.getLink());
+        assertEquals(unixPath, unixRecord.getLink(), "should match file name");
     }
 }

--- a/src/test/java/hudson/plugins/s3/MinIOTest.java
+++ b/src/test/java/hudson/plugins/s3/MinIOTest.java
@@ -28,7 +28,6 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import hudson.EnvVars;
 import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.Launcher;

--- a/src/test/java/hudson/plugins/s3/S3BucketPublisherTest.java
+++ b/src/test/java/hudson/plugins/s3/S3BucketPublisherTest.java
@@ -1,23 +1,23 @@
 package hudson.plugins.s3;
 
-import org.htmlunit.HttpMethod;
-import org.htmlunit.WebRequest;
-import org.htmlunit.util.UrlUtils;
 import hudson.model.Item;
 import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.htmlunit.HttpMethod;
+import org.htmlunit.WebRequest;
+import org.htmlunit.util.UrlUtils;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class S3BucketPublisherTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WithJenkins
+class S3BucketPublisherTest {
 
     @Test
-    public void testConfigExists() throws Exception {
+    void testConfigExists(JenkinsRule j) throws Exception {
         SecurityRealm securityRealm = j.createDummySecurityRealm();
         j.getInstance().setSecurityRealm(securityRealm);
         j.getInstance().setAuthorizationStrategy(
@@ -34,9 +34,9 @@ public class S3BucketPublisherTest {
                 HttpMethod.POST);
 
         webClient.login("bob", "bob");
-        Assert.assertEquals(403, webClient.getPage(request).getWebResponse().getStatusCode());
+        assertEquals(403, webClient.getPage(request).getWebResponse().getStatusCode());
 
         webClient = j.createWebClient().login("alice", "alice");
-        Assert.assertEquals(200, webClient.getPage(request).getWebResponse().getStatusCode());
+        assertEquals(200, webClient.getPage(request).getWebResponse().getStatusCode());
     }
 }

--- a/src/test/java/hudson/plugins/s3/S3CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/s3/S3CopyArtifactTest.java
@@ -1,55 +1,45 @@
 package hudson.plugins.s3;
+
 import hudson.model.FreeStyleProject;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class S3CopyArtifactTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-    private String projectName;
-    private String filter;
-    private String excludeFilter;
-    private String target;
-    private boolean flatten;
-    private boolean option;
+@WithJenkins
+class S3CopyArtifactTest {
 
-    @Before
-    public void setUp() throws Exception {
-        projectName = "projectA";
-        filter = "filterA";
-        excludeFilter = "excludeFilterA";
-        target = "targetA";
-        flatten = true;
-        option = true;
-    }
+    private static final String PROJECT_NAME = "projectA";
+    private static final String FILTER = "filterA";
+    private static final String EXCLUDE_FILTER = "excludeFilterA";
+    private static final String TARGET = "targetA";
+    private static final boolean FLATTEN = true;
+    private static final boolean OPTION = true;
 
     @Test
-    public void testConfigParser() throws Exception {
-        j.createFreeStyleProject(projectName);
-        S3CopyArtifact before = new S3CopyArtifact(projectName, null, filter, excludeFilter, target, flatten, option);
+    void testConfigParser(JenkinsRule j) throws Exception {
+        j.createFreeStyleProject(PROJECT_NAME);
+        S3CopyArtifact before = new S3CopyArtifact(PROJECT_NAME, null, FILTER, EXCLUDE_FILTER, TARGET, FLATTEN, OPTION);
 
-        S3CopyArtifact after = recreateFromConfig(before);
+        S3CopyArtifact after = recreateFromConfig(j, before);
 
-        testGetters(after, projectName, filter, excludeFilter, target, flatten, option);
+        testGetters(after, PROJECT_NAME, FILTER, EXCLUDE_FILTER, TARGET, FLATTEN, OPTION);
         j.assertEqualBeans(before, after, "projectName,filter,excludeFilter,target,flatten,optional");
     }
 
     @Test
-    public void testConfigParserIncorrectProject() throws Exception {
+    void testConfigParserIncorrectProject(JenkinsRule j) throws Exception {
         j.createFreeStyleProject("projectB");
-        S3CopyArtifact before = new S3CopyArtifact(projectName, null, filter, excludeFilter, target, flatten, option);
+        S3CopyArtifact before = new S3CopyArtifact(PROJECT_NAME, null, FILTER, EXCLUDE_FILTER, TARGET, FLATTEN, OPTION);
 
-        S3CopyArtifact after = recreateFromConfig(before);
+        S3CopyArtifact after = recreateFromConfig(j, before);
 
-        testGetters(after, "", filter, excludeFilter, target, flatten, option);
+        testGetters(after, "", FILTER, EXCLUDE_FILTER, TARGET, FLATTEN, OPTION);
         j.assertEqualBeans(before, after, "projectName,filter,excludeFilter,target,flatten,optional");
     }
 
-    private S3CopyArtifact recreateFromConfig(S3CopyArtifact before) throws Exception {
+    private S3CopyArtifact recreateFromConfig(JenkinsRule j, S3CopyArtifact before) throws Exception {
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(before);
 

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -1,8 +1,5 @@
 package hudson.plugins.s3;
 
-
-import org.htmlunit.WebAssert;
-import org.htmlunit.html.HtmlPage;
 import hudson.Functions;
 import hudson.model.Action;
 import hudson.model.FreeStyleBuild;
@@ -16,9 +13,11 @@ import hudson.tasks.Builder;
 import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.tasks.Shell;
 import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import org.htmlunit.WebAssert;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -28,20 +27,19 @@ import java.util.List;
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.collect.Lists.newArrayList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class S3Test {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class S3Test {
 
     @Test
-    public void testConfigExists() throws Exception {
+    void testConfigExists(JenkinsRule j) throws Exception {
         HtmlPage page = j.createWebClient().goTo("configure");
         WebAssert.assertTextPresent(page, "S3 profiles");
     }
 
     @Test
-    public void testConfigContainsProfiles() throws Exception {
+    void testConfigContainsProfiles(JenkinsRule j) throws Exception {
         final S3Profile profile = new S3Profile("S3 profile random name", null, null, true, 0, "0", "0", "0", "0", true);
 
         replaceS3PluginProfile(profile);
@@ -51,13 +49,13 @@ public class S3Test {
     }
 
     @Test
-    public void multiplePublishersUseExistingActions() throws Exception {
+    void multiplePublishersUseExistingActions(JenkinsRule j) throws Exception {
         String profileName = "test profile";
         String fileName = "testFile";
         S3BucketPublisher publisher = new S3BucketPublisher(
                 profileName,
                 newArrayList(entryForFile(fileName)),
-                Collections.<MetadataPair>emptyList(),
+                Collections.emptyList(),
                 true,
                 "INFO",
                 "SUCCESS",
@@ -77,14 +75,14 @@ public class S3Test {
     }
 
     @Test
-    public void dontSetBuildResultTest() throws Exception {
+    void dontSetBuildResultTest(JenkinsRule j) throws Exception {
         String profileName = "test profile";
         String missingProfileName = "test profile missing";
         String fileName = "testFile";
         S3BucketPublisher missingPublisher = new S3BucketPublisher(
                 missingProfileName,
                 newArrayList(entryForFile(fileName)),
-                Collections.<MetadataPair>emptyList(),
+                Collections.emptyList(),
                 true,
                 "DEBUG",
                 "SUCCESS",
@@ -114,7 +112,7 @@ public class S3Test {
     }
 
     private void replaceS3PluginProfile(S3Profile s3Profile) {
-        final Jenkins instance = Jenkins.getInstance();
+        final Jenkins instance = Jenkins.get();
         final DescriptorImpl s3Plugin = (DescriptorImpl) instance.getDescriptor(S3BucketPublisher.class);
         s3Plugin.replaceProfiles(newArrayList(s3Profile));
     }


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations
* Migrate assertions
* Minor cleanup
* Remove public visibility of test classes and methods

There is once exception in `hudson.plugins.s3.MinIOTest` which was not migrated as it uses `RealJenkinsRule` for which there is no JUnit4 equivalent yet.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewd.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

