### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,19 +3,21 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.4</version>
+        <version>5.7</version>
     </parent>
 
     <artifactId>s3</artifactId>
     <packaging>hpi</packaging>
     <version>${changelist}</version>
     <name>Jenkins S3 publisher plugin</name>
-    <url>https://github.com/jenkinsci/s3-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <gitHubRepo>jenkinsci/s3-plugin</gitHubRepo>
-        <jenkins.version>2.479.1</jenkins.version>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     </properties>
 
     <developers>
@@ -100,8 +102,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.479.x</artifactId>
-                <version>3875.v1df09947cde6</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3893.v213a_42768d35</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
+++ b/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
@@ -7,21 +7,21 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ResponseHeaderOverrides;
 import hudson.Functions;
 import jenkins.model.RunAction2;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 import hudson.model.Run;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 @ExportedBean
 public class S3ArtifactsAction implements RunAction2 {
@@ -75,7 +75,7 @@ public class S3ArtifactsAction implements RunAction2 {
         return artifacts;
     }
 
-    public void doDownload(final StaplerRequest request, final StaplerResponse response) throws IOException, ServletException {
+    public void doDownload(final StaplerRequest2 request, final StaplerResponse2 response) throws IOException, ServletException {
         if (Functions.isArtifactsPermissionEnabled()) {
             build.getParent().checkPermission(Run.ARTIFACTS);
         }

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -40,7 +40,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import java.io.IOException;
@@ -483,7 +483,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) {
+        public boolean configure(StaplerRequest2 req, JSONObject json) {
             final JSONArray array = json.optJSONArray("profile");
             if (array != null) {
                 profiles.replaceBy(req.bindJSONToList(S3Profile.class, array));


### PR DESCRIPTION
Migrate from deprecated EE 8 functionality to non-deprecated EE 9 equivalents.


### Testing done

`mvn clean verify`