### PR TITLE
Use pathstyle links for presign urls if a custom endpoint is used

### DIFF
--- a/src/main/java/hudson/plugins/s3/ClientHelper.java
+++ b/src/main/java/hudson/plugins/s3/ClientHelper.java
@@ -39,7 +39,12 @@ public class ClientHelper {
         }
     }
 
+    @Deprecated
     public static S3AsyncClient createAsyncClient(String accessKey, String secretKey, boolean useRole, String region, @CheckForNull ProxyConfiguration proxy, @CheckForNull URI customEndpoint, Long thresholdInBytes) {
+        return createAsyncClient(accessKey, secretKey, useRole, region, proxy, customEndpoint, thresholdInBytes, false);
+    }
+
+    public static S3AsyncClient createAsyncClient(String accessKey, String secretKey, boolean useRole, String region, @CheckForNull ProxyConfiguration proxy, @CheckForNull URI customEndpoint, Long thresholdInBytes, boolean usePathStyle) {
         Region awsRegion = getRegionFromString(region);
         S3AsyncClientBuilder builder = S3AsyncClient.builder();//.overrideConfiguration(clientConfiguration);
         builder.region(awsRegion);
@@ -49,10 +54,10 @@ public class ClientHelper {
         }
 
         if (customEndpoint != null) {
-            builder = builder.endpointOverride(customEndpoint).forcePathStyle(true);
+            builder = builder.endpointOverride(customEndpoint).forcePathStyle(usePathStyle);
             builder.httpClient(getAsyncHttpClient(customEndpoint, proxy));
         } else if (ENDPOINT_URI != null) {
-            builder = builder.endpointOverride(ENDPOINT_URI).forcePathStyle(true);
+            builder = builder.endpointOverride(ENDPOINT_URI).forcePathStyle(usePathStyle);
             builder.httpClient(getAsyncHttpClient(ENDPOINT_URI, proxy));
         } else {
             builder.httpClient(getAsyncHttpClient(null, proxy));
@@ -63,11 +68,21 @@ public class ClientHelper {
         return builder.build();
     }
 
+    @Deprecated
     public static S3Client createClient(String accessKey, String secretKey, boolean useRole, String region, ProxyConfiguration proxy) {
-        return createClient(accessKey, secretKey, useRole, region, proxy, ENDPOINT_URI);
+        return createClient(accessKey, secretKey, useRole, region, proxy, ENDPOINT_URI, false);
     }
 
+    public static S3Client createClient(String accessKey, String secretKey, boolean useRole, String region, ProxyConfiguration proxy, boolean usePathStyle) {
+        return createClient(accessKey, secretKey, useRole, region, proxy, ENDPOINT_URI, usePathStyle);
+    }
+
+    @Deprecated
     public static S3Client createClient(String accessKey, String secretKey, boolean useRole, String region, ProxyConfiguration proxy, @CheckForNull URI customEndpoint) {
+        return createClient(accessKey, secretKey, useRole, region, proxy, customEndpoint, false);
+    }
+
+    public static S3Client createClient(String accessKey, String secretKey, boolean useRole, String region, ProxyConfiguration proxy, @CheckForNull URI customEndpoint, boolean usePathStyle) {
         Region awsRegion = getRegionFromString(region);
         S3ClientBuilder builder = S3Client.builder();
         builder.region(awsRegion);
@@ -78,10 +93,10 @@ public class ClientHelper {
 
         try {
             if (customEndpoint != null) {
-                builder = builder.endpointOverride(customEndpoint).forcePathStyle(true);
+                builder = builder.endpointOverride(customEndpoint).forcePathStyle(usePathStyle);
                 builder.httpClient(getHttpClient(customEndpoint, proxy));
             } else if (ENDPOINT_URI != null) {
-                builder = builder.endpointOverride(ENDPOINT_URI).forcePathStyle(true);
+                builder = builder.endpointOverride(ENDPOINT_URI).forcePathStyle(usePathStyle);
                 builder.httpClient(getHttpClient(ENDPOINT_URI, proxy));
             } else {
                 builder.httpClient(getHttpClient(null, proxy));

--- a/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
+++ b/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -117,6 +118,9 @@ public class S3ArtifactsAction implements RunAction2 {
                 .region(Region.of(record.getArtifact().getRegion()));
         if (ClientHelper.ENDPOINT_URI != null) {
             presignerBuilder.endpointOverride(ClientHelper.ENDPOINT_URI);
+        }
+        if (s3.isUsePathStyle()) {
+            presignerBuilder.serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build());
         }
         if (!s3.isUseRole()) {
             presignerBuilder.credentialsProvider(() -> AwsBasicCredentials.create(s3.getAccessKey(), Secret.toString(s3.getSecretKey())));

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -557,7 +557,8 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         @SuppressWarnings("unused")
         @RequirePOST
         public FormValidation doLoginCheck(@QueryParameter String name, @QueryParameter String accessKey,
-                                           @QueryParameter Secret secretKey, @QueryParameter boolean useRole) {
+                                           @QueryParameter Secret secretKey, @QueryParameter boolean useRole,
+                                           @QueryParameter boolean usePathStyle) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
             final String checkedName = Util.fixNull(name);
@@ -586,7 +587,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
             final String defaultRegion = ClientHelper.DEFAULT_AMAZON_S3_REGION_NAME;
 
-            try (var client = ClientHelper.createClient(checkedAccessKey, checkedSecretKey, useRole, defaultRegion, Jenkins.get().getProxy())) {
+            try (var client = ClientHelper.createClient(checkedAccessKey, checkedSecretKey, useRole, defaultRegion, Jenkins.get().getProxy(), usePathStyle)) {
                 client.listBuckets();
             } catch (SdkException e) {
                 LOGGER.log(Level.SEVERE, e.getMessage(), e);

--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -27,8 +27,8 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
 
     public S3BaseUploadCallable(String accessKey, Secret secretKey, boolean useRole,
                                 Destination dest, Map<String, String> userMetadata, String storageClass, String selregion,
-                                boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, selregion, proxy);
+                                boolean useServerSideEncryption, ProxyConfiguration proxy, boolean usePathStyle) {
+        super(accessKey, secretKey, useRole, selregion, proxy, usePathStyle);
         this.dest = dest;
         this.storageClass = storageClass;
         this.userMetadata = userMetadata;

--- a/src/main/java/hudson/plugins/s3/callable/S3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3Callable.java
@@ -25,16 +25,19 @@ abstract class S3Callable<T> implements FileCallable<T> {
     private final String region;
     private final ProxyConfiguration proxy;
     private final String customEndpoint;
+    private final boolean usePathStyle;
 
     private static final HashMap<String, S3TransferManager> transferManagers = new HashMap<>();
 
-    S3Callable(String accessKey, Secret secretKey, boolean useRole, String region, ProxyConfiguration proxy) {
+    S3Callable(String accessKey, Secret secretKey, boolean useRole, String region, ProxyConfiguration proxy, boolean usePathStyle) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.useRole = useRole;
         this.region = region;
         this.proxy = proxy;
         this.customEndpoint = ClientHelper.ENDPOINT;
+        this.usePathStyle = usePathStyle;
+
     }
 
     protected synchronized S3TransferManager getTransferManager() {
@@ -48,7 +51,8 @@ abstract class S3Callable<T> implements FileCallable<T> {
                         region,
                         proxy,
                         isNotEmpty(customEndpoint) ? new URI(customEndpoint) : null,
-                        (long)Uploads.MULTIPART_UPLOAD_THRESHOLD);
+                        (long)Uploads.MULTIPART_UPLOAD_THRESHOLD,
+                        usePathStyle);
                 transferManagers.put(uniqueKey, S3TransferManager.builder().s3Client(client).build());
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3DownloadCallable.java
@@ -16,9 +16,9 @@ public final class S3DownloadCallable extends S3Callable<String>
     private static final long serialVersionUID = 1L;
     private final Destination dest;
     
-    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, String region, ProxyConfiguration proxy)
+    public S3DownloadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, String region, ProxyConfiguration proxy, boolean usePathStyle)
     {
-        super(accessKey, secretKey, useRole, region, proxy);
+        super(accessKey, secretKey, useRole, region, proxy, usePathStyle);
         this.dest = dest;
     }
 

--- a/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3GzipCallable.java
@@ -22,8 +22,8 @@ import java.util.logging.Logger;
 import java.util.zip.GZIPOutputStream;
 
 public final class S3GzipCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
-    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3GzipCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy, boolean usePathStyle) {
+        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy, usePathStyle);
     }
 
     // Return a File containing the gzipped contents of the input file.

--- a/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3UploadCallable.java
@@ -13,8 +13,8 @@ import java.util.Map;
 public final class S3UploadCallable extends S3BaseUploadCallable implements MasterSlaveCallable<String> {
     private static final long serialVersionUID = 1L;
 
-    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy) {
-        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy);
+    public S3UploadCallable(String accessKey, Secret secretKey, boolean useRole, Destination dest, Map<String, String> userMetadata, String storageClass, String selregion, boolean useServerSideEncryption, ProxyConfiguration proxy, boolean usePathStyle) {
+        super(accessKey, secretKey, useRole, dest, userMetadata, storageClass, selregion, useServerSideEncryption, proxy, usePathStyle);
     }
 
     /**

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -40,6 +40,9 @@
             <f:entry title="Keep Structure" help="/plugin/s3/help-keepStructure.html">
                 <f:checkbox name="s3.keepStructure" value="${profile.keepStructure}" checked="${profile.keepStructure}"/>
             </f:entry>
+            <f:entry title="Use Path Style URL" help="/plugin/s3/help-pathStyle.html">
+              <f:checkbox name="usePathStyle" checked="${profile.usePathStyle}"/>
+            </f:entry>
           </f:advanced>
 
           <f:entry title="">

--- a/src/main/webapp/help-pathStyle.html
+++ b/src/main/webapp/help-pathStyle.html
@@ -1,0 +1,1 @@
+<div>If ticked uses path-style addressing for buckets</div>

--- a/src/test/java/hudson/plugins/s3/MinIOTest.java
+++ b/src/test/java/hudson/plugins/s3/MinIOTest.java
@@ -174,12 +174,14 @@ public class MinIOTest {
 
     private static void createProfile() {
         final S3BucketPublisher.DescriptorImpl descriptor = ExtensionList.lookup(S3BucketPublisher.DescriptorImpl.class).get(0);
-        descriptor.replaceProfiles(Collections.singletonList(new S3Profile(
+        S3Profile profile = new S3Profile(
                 "Local",
                 ACCESS_KEY, SECRET_KEY,
                 false,
                 10000,
-                "", "", "", "", true)));
+                "", "", "", "", true);
+        profile.setUsePathStyle(true);
+        descriptor.replaceProfiles(Collections.singletonList(profile));
     }
 
     @Test


### PR DESCRIPTION
We use a self-hosted MinIO as an S3-provider and the PR https://github.com/jenkinsci/s3-plugin/pull/327 broke generating presign urls. In the versions before than `505.v8f71dcce8639` the link format was:

`<MINIO_ENDPOINT>/<S3_BUCKET_NAME>/<PATH_TO_FILE>`

After updating to `505.v8f71dcce8639` it became the following:

`<S3_BUCKET_NAME>.<MINIO_ENDPOINT>/<PATH_TO_FILE>`

and of course it's not working.

The fix is to enable `pathStyleAccessEnabled` if the ENDPOINT is configured. The fix was tested locally and it's working.