### PR TITLE
Remove artifacts from S3 for deleted pipelines

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -43,6 +43,7 @@ public class S3Profile {
     private final boolean useRole;
     private final int signedUrlExpirySeconds;
     private boolean usePathStyle = false;
+    private boolean deleteArtifactsRecursively = false;
 
     @DataBoundConstructor
     public S3Profile(String name, String accessKey, String secretKey, boolean useRole, int signedUrlExpirySeconds, String maxUploadRetries, String uploadRetryTime, String maxDownloadRetries, String downloadRetryTime, boolean keepStructure) {
@@ -67,6 +68,11 @@ public class S3Profile {
     @DataBoundSetter
     public void setUsePathStyle(boolean usePathStyle) {
         this.usePathStyle = usePathStyle;
+    }
+
+    @DataBoundSetter
+    public void setDeleteArtifactsRecursively(boolean deleteArtifactsRecursively) {
+        this.deleteArtifactsRecursively = deleteArtifactsRecursively;
     }
 
     public boolean isKeepStructure() {
@@ -122,6 +128,8 @@ public class S3Profile {
     }
 
     public boolean isUsePathStyle() { return usePathStyle; }
+
+    public boolean isDeleteArtifactsRecursively() { return deleteArtifactsRecursively; }
 
     public S3Client getClient(String region) {
         return ClientHelper.createClient(accessKey, Secret.toString(secretKey), useRole, region, getProxy(), usePathStyle);

--- a/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/s3/S3BucketPublisher/global.jelly
@@ -43,6 +43,9 @@
             <f:entry title="Use Path Style URL" help="/plugin/s3/help-pathStyle.html">
               <f:checkbox name="usePathStyle" checked="${profile.usePathStyle}"/>
             </f:entry>
+            <f:entry title="Delete Artifacts Recursively" help="/plugin/s3/help-deleteArtifactsRecursively.html">
+              <f:checkbox name="deleteArtifactsRecursively" checked="${profile.deleteArtifactsRecursively}"/>
+            </f:entry>
           </f:advanced>
 
           <f:entry title="">

--- a/src/main/webapp/help-deleteArtifactsRecursively.html
+++ b/src/main/webapp/help-deleteArtifactsRecursively.html
@@ -1,0 +1,1 @@
+<div>If ticked deletes artifacts recursively in case of pipeline or folder deletion</div>


### PR DESCRIPTION
Currently, the `s3-plugin` plugin deletes the artifacts from S3 only if the corresponding build has been deleted. However, if a job (pipeline) is deleted, the artifacts that were uploaded to S3 by its builds will remain there indefinitely (unless they are manually deleted from S3).

For example, in our environment we actively use the plugin with multi-branch pipelines - for every PR a pipeline is created automatically. When the PR is closed, the corresponding pipeline is deleted automatically, but the artifacts are still kept on S3. As a result, we accumulate a lot of unnecessary data and we need to clean them manually.

This PR adds a new option to the S3 profile - `deleteArtifactsRecursively`. When enabled (by default it's `false`), the plugin deletes the artifacts recursively if a pipeline (or a folder / organization folder) is deleted.