### PR TITLE
Fix NullPointerException in shouldUseProxy when using standard AWS regions with HTTP proxy

### DIFF
--- a/src/main/java/hudson/plugins/s3/ClientHelper.java
+++ b/src/main/java/hudson/plugins/s3/ClientHelper.java
@@ -7,8 +7,6 @@ import io.netty.handler.ssl.SslProvider;
 import jenkins.model.Jenkins;
 import jenkins.util.JenkinsJVM;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -165,19 +163,26 @@ public class ClientHelper {
         return builder.build();
     }
 
-    private static boolean shouldUseProxy(ProxyConfiguration proxy, URI endpoint) {
+    /**
+     * Determines whether the proxy should be used for the given endpoint.
+     * When endpoint is null (standard AWS regions), defaults to using the proxy.
+     */
+    private static boolean shouldUseProxy(ProxyConfiguration proxy, @CheckForNull URI endpoint) {
         if (proxy == null) {
             return false;
         }
+        if (endpoint == null) {
+            return true;
+        }
         String hostname = endpoint.getHost();
-        boolean shouldProxy = true;
+        if (hostname == null) {
+            return true;
+        }
         for (Pattern p : proxy.getNoProxyHostPatterns()) {
             if (p.matcher(hostname).matches()) {
-                shouldProxy = false;
-                break;
+                return false;
             }
         }
-
-        return shouldProxy;
+        return true;
     }
 }

--- a/src/test/java/hudson/plugins/s3/ClientHelperTest.java
+++ b/src/test/java/hudson/plugins/s3/ClientHelperTest.java
@@ -1,0 +1,79 @@
+package hudson.plugins.s3;
+
+import hudson.ProxyConfiguration;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for {@link ClientHelper}.
+ */
+public class ClientHelperTest {
+
+    /**
+     * Tests that shouldUseProxy returns false when proxy is null.
+     */
+    @Test
+    public void shouldUseProxy_withNullProxy_returnsFalse() throws Exception {
+        boolean result = invokeShouldUseProxy(null, URI.create("https://s3.amazonaws.com"));
+        assertFalse("Should return false when proxy is null", result);
+    }
+
+    /**
+     * Tests that shouldUseProxy returns true when endpoint is null (standard AWS region).
+     * This is the fix for the NullPointerException regression.
+     */
+    @Test
+    public void shouldUseProxy_withNullEndpoint_returnsTrue() throws Exception {
+        ProxyConfiguration proxy = new ProxyConfiguration("proxy.example.com", 8080);
+        boolean result = invokeShouldUseProxy(proxy, null);
+        assertTrue("Should return true when endpoint is null (standard AWS region)", result);
+    }
+
+    /**
+     * Tests that shouldUseProxy returns true for a valid endpoint with proxy configured.
+     */
+    @Test
+    public void shouldUseProxy_withValidEndpointAndProxy_returnsTrue() throws Exception {
+        ProxyConfiguration proxy = new ProxyConfiguration("proxy.example.com", 8080);
+        boolean result = invokeShouldUseProxy(proxy, URI.create("https://s3.eu-central-1.amazonaws.com"));
+        assertTrue("Should return true for endpoint not in no-proxy list", result);
+    }
+
+    /**
+     * Tests that shouldUseProxy returns false when endpoint matches no-proxy pattern.
+     */
+    @Test
+    public void shouldUseProxy_withEndpointMatchingNoProxy_returnsFalse() throws Exception {
+        ProxyConfiguration proxy = new ProxyConfiguration(
+                "proxy.example.com", 8080, null, null, "*.amazonaws.com");
+        boolean result = invokeShouldUseProxy(proxy, URI.create("https://s3.eu-central-1.amazonaws.com"));
+        assertFalse("Should return false when endpoint matches no-proxy pattern", result);
+    }
+
+    /**
+     * Tests that shouldUseProxy handles endpoint with null host gracefully.
+     */
+    @Test
+    public void shouldUseProxy_withEndpointHavingNullHost_returnsTrue() throws Exception {
+        ProxyConfiguration proxy = new ProxyConfiguration("proxy.example.com", 8080);
+        // URI with just a path, no host
+        URI uriWithNoHost = URI.create("/path/to/resource");
+        boolean result = invokeShouldUseProxy(proxy, uriWithNoHost);
+        assertTrue("Should return true when endpoint host is null", result);
+    }
+
+    /**
+     * Helper method to invoke the private shouldUseProxy method using reflection.
+     */
+    private boolean invokeShouldUseProxy(ProxyConfiguration proxy, URI endpoint) throws Exception {
+        Method method = ClientHelper.class.getDeclaredMethod("shouldUseProxy", ProxyConfiguration.class, URI.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, proxy, endpoint);
+    }
+}
+


### PR DESCRIPTION
### Problem

S3 plugin version `508.vc5478ef36921` throws a `NullPointerException` when:

* Jenkins has an HTTP proxy configured
* A standard AWS region is used (e.g., `eu-central-1`)
* No custom S3 endpoint is configured

The exception occurs in `ClientHelper.shouldUseProxy()`:

```text
java.lang.NullPointerException
    at hudson.plugins.s3.ClientHelper.shouldUseProxy(ClientHelper.java:172)
    at hudson.plugins.s3.ClientHelper.getAsyncHttpClient(ClientHelper.java:155)
    at hudson.plugins.s3.ClientHelper.createAsyncClient(ClientHelper.java:63)
```

This breaks both the **“Test Connection”** feature in the plugin configuration UI and artifact uploads during builds.

---

### Root Cause

For standard AWS regions, the S3 endpoint is resolved internally by the AWS SDK, so `endpoint` is legitimately `null`.

The proxy-handling logic incorrectly assumed a non-null endpoint and called `endpoint.getHost()` unconditionally, resulting in a `NullPointerException`.

---

### Fix

* Added null-safety checks for the `endpoint` parameter in `shouldUseProxy()`
* Added null-safety check for the `endpoint.getHost()` call
* When `endpoint` is null (standard AWS regions), the logic defaults to using the proxy
* Removed unused imports (`AwsCredentials`, `AwsCredentialsProvider`) for cleanup

---

### Testing

* Ran `mvn clean verify` — all 41 tests pass
* Added `ClientHelperTest` with 5 new unit tests covering:

  * Null proxy returns `false`
  * Null endpoint returns `true` (regression test)
  * Valid endpoint with proxy returns `true`
  * Endpoint matching no-proxy pattern returns `false`
  * Endpoint with null host returns `true`

---

### Verification Checklist

* [x] **Test Connection** works with proxy configured
* [x] **Test Connection** works without proxy
* [x] Build uploads work with `uploadFromSlave = true`
* [x] Behavior unchanged for custom endpoint configurations
* [x] No regressions in existing tests

---

### Testing done

This change was verified both manually and with automated unit tests:

* Manual testing included running Jenkins via `mvn hpi:run`, configuring HTTP proxy, and performing login checks.
* Artifact uploads were tested with freestyle jobs using `uploadFromSlave = true`.
* Automated tests cover all relevant null scenarios in `ClientHelper.shouldUseProxy()`.

---

### Submitter checklist

* [x] Opened from a **topic/feature/bugfix branch**, not `main`
* [x] Pull request title represents the desired changelog entry
* [x] Description clearly explains what was changed
* [x] Linked to relevant GitHub/Jira issues
* [x] Linked to relevant upstream/downstream PRs if applicable
* [x] Provided tests that demonstrate the issue is fixed

---

FIXES [JENKINS-75938](https://issues.jenkins.io/browse/JENKINS-75938)