### PR TITLE
[JENKINS-76354] - resolve indefinite hang in s3Upload caused by untimeout'd future join

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class S3Profile {
     private final String name;
@@ -275,15 +277,21 @@ public class S3Profile {
 
     private <T> T repeat(int maxRetries, int waitTime, Destination dest, Callable<T> func) throws IOException, InterruptedException {
         int retryCount = 0;
+        Logger LOGGER = Logger.getLogger(S3Profile.class.getName());
 
         while (true) {
             try {
                 return func.call();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
             } catch (Exception e) {
                 retryCount++;
                 if(retryCount >= maxRetries){
                     throw new IOException("Call fails for " + dest + ": " + e + ":: Failed after " + retryCount + " tries.", e);
                 }
+                LOGGER.log(Level.WARNING, "Upload attempt {0}/{1} failed for {2}: {3}. Retrying in {4}s",
+                        new Object[]{retryCount, maxRetries, dest, e.getMessage(), waitTime});
                 Thread.sleep(TimeUnit.SECONDS.toMillis(waitTime));
             }
         }

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -4,7 +4,6 @@ import hudson.FilePath;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
@@ -14,9 +13,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -28,9 +30,22 @@ public final class Uploads {
     public static final int MULTIPART_UPLOAD_THRESHOLD = 16*1024*1024; // 16 MB
 
     private static transient volatile Uploads instance;
-    private final transient HashMap<FilePath, Upload> startedUploads = new HashMap<>();
-    private final ExecutorService executors = Executors.newScheduledThreadPool(1, new NamedThreadFactory(Executors.defaultThreadFactory(), Uploads.class.getName()));
-    private final transient HashMap<FilePath, InputStream> openedStreams = new HashMap<>();
+
+    private final transient Map<FilePath, Upload> startedUploads = new ConcurrentHashMap<>();
+    private final ExecutorService executors;
+    // This creates a cached thread pool with an upper bound (5) on threads to be spawned on demand.
+    {
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+            5, 5,
+            60L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            new NamedThreadFactory(Executors.defaultThreadFactory(), Uploads.class.getName())
+        );
+        pool.allowCoreThreadTimeOut(true);
+        executors = pool;
+    }
+
+    private final transient Map<FilePath, InputStream> openedStreams = new ConcurrentHashMap<>();
 
     public Upload startUploading(S3TransferManager manager, FilePath file, InputStream inputStream, String bucketName, String objectName, Metadata metadata, TransferListener listener) {
         UploadRequest.Builder request = UploadRequest.builder();

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -14,8 +14,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -43,16 +46,24 @@ public final class Uploads {
         return upload;
     }
 
-    public void finishUploading(FilePath filePath) throws InterruptedException {
+    public void finishUploading(FilePath filePath) throws InterruptedException, IOException {
         final Upload upload = startedUploads.remove(filePath);
         if (upload == null) {
             LOGGER.info("File: " + filePath.getName() + " already was uploaded");
             return;
         }
         try {
-            upload.completionFuture().join();
-        }
-        finally {
+            upload.completionFuture().get(1, TimeUnit.HOURS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            upload.completionFuture().cancel(true); // cancel the upload
+            throw e;
+        } catch (ExecutionException e) {
+            throw new IOException("Upload failed for: " + filePath.getName(), e.getCause());
+        } catch (TimeoutException e) {
+            upload.completionFuture().cancel(true);
+            throw new IOException("Upload timed out for: " + filePath.getName(), e);
+        } finally {
             closeStream(filePath);
         }
     }

--- a/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
@@ -7,16 +7,17 @@ import jenkins.security.Roles;
 import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class S3WaitUploadCallable implements MasterSlaveCallable<Void> {
     @Override
-    public Void invoke(File f, VirtualChannel channel) throws InterruptedException {
+    public Void invoke(File f, VirtualChannel channel) throws InterruptedException, IOException {
         invoke(new FilePath(f));
         return null;
     }
 
     @Override
-    public Void invoke(FilePath file) throws InterruptedException {
+    public Void invoke(FilePath file) throws InterruptedException, IOException {
         Uploads.getInstance().finishUploading(file);
         return null;
     }


### PR DESCRIPTION
Fixes [JENKINS-76354](https://issues.jenkins.io/browse/JENKINS-76354)

- `CompletableFuture#join` can indefinitely block finishing uploads in certain instances. So it has been changed to `.get()` with a timeout to prevent upload hangs.
- Logging upload retry attempts has also been added.
- Minor optimization: A custom cached thread pool with upper bound for concurrent uploads.

<!-- Please describe your pull request here. -->

### Testing done

- Triggered a job with multiple artifact uploads to S3. Verified all files uploaded successfully without any hang.
- Concurrent uploads: Uploaded several files simultaneously to confirm new `ThreadPoolExecutor` with debug logs.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Note

While the exact conditions described in the issue could not be fully reproduced after various attempts, the root cause - `CompletableFuture#join` has been addressed and replaced by its equivalent - `get()` with a timeout

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
