### PR TITLE
Add configurable timeout for uploads

### DIFF
--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -41,6 +41,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -68,6 +69,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
     private boolean dontWaitForConcurrentBuildCompletion;
     private boolean dontSetBuildResultOnFailure;
+    private int uploadTimeout = 30; // default 30 mins
 
     /**
      * In-memory representation of console log level.
@@ -88,6 +90,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
      * User metadata key/value pairs to tag the upload with.
      */
     private /*almost final*/ List<MetadataPair> userMetadata;
+
 
     @DataBoundConstructor
     public S3BucketPublisher(String profileName, List<Entry> entries, List<MetadataPair> userMetadata,
@@ -241,6 +244,16 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
         return ImmutableList.of(new S3ArtifactsProjectAction(project));
     }
+
+    public int getUploadTimeout() {
+        return uploadTimeout;
+    }
+
+    @DataBoundSetter
+    public void setUploadTimeout(int uploadTimeout) {
+        this.uploadTimeout = Math.max(uploadTimeout, Uploads.MIN_UPLOAD_TIMEOUT);
+    }
+
 
     private void log(final PrintStream logger, final String message) {
         log(Level.INFO, logger, message);

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -91,7 +91,6 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
      */
     private /*almost final*/ List<MetadataPair> userMetadata;
 
-
     @DataBoundConstructor
     public S3BucketPublisher(String profileName, List<Entry> entries, List<MetadataPair> userMetadata,
                              boolean dontWaitForConcurrentBuildCompletion, String consoleLogLevel, String pluginFailureResultConstraint,
@@ -254,7 +253,6 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
         this.uploadTimeout = Math.max(uploadTimeout, Uploads.MIN_UPLOAD_TIMEOUT);
     }
 
-
     private void log(final PrintStream logger, final String message) {
         log(Level.INFO, logger, message);
     }
@@ -340,7 +338,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
                 final Map<String, String> escapedMetadata = buildMetadata(envVars, entry);
 
                 final List<FingerprintRecord> records = Lists.newArrayList();
-                final List<FingerprintRecord> fingerprints = profile.upload(run, bucket, paths, filenames, escapedMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.gzipFiles);
+                final List<FingerprintRecord> fingerprints = profile.upload(run, bucket, paths, filenames, escapedMetadata, storageClass, selRegion, entry.uploadFromSlave, entry.managedArtifacts, entry.useServerSideEncryption, entry.gzipFiles, uploadTimeout);
 
                 for (FingerprintRecord fingerprintRecord : fingerprints) {
                     records.add(fingerprintRecord);

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -27,7 +27,6 @@ import hudson.tasks.Fingerprinter.FingerprintAction;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.CopyOnWriteList;
-import hudson.util.FormFillFailure;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
@@ -242,10 +241,6 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
     @Override @NonNull
     public Collection<? extends Action> getProjectActions(AbstractProject<?, ?> project) {
         return ImmutableList.of(new S3ArtifactsProjectAction(project));
-    }
-
-    public int getUploadTimeout() {
-        return uploadTimeout;
     }
 
     @DataBoundSetter

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class S3Profile {
     private final String name;
@@ -275,15 +277,21 @@ public class S3Profile {
 
     private <T> T repeat(int maxRetries, int waitTime, Destination dest, Callable<T> func) throws IOException, InterruptedException {
         int retryCount = 0;
+        Logger LOGGER = Logger.getLogger(S3Profile.class.getName());
 
         while (true) {
             try {
                 return func.call();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw e;
             } catch (Exception e) {
                 retryCount++;
                 if(retryCount >= maxRetries){
                     throw new IOException("Call fails for " + dest + ": " + e + ":: Failed after " + retryCount + " tries.", e);
                 }
+                LOGGER.log(Level.WARNING, "Upload attempt {0}/{1} failed for {2}: {3}. Retrying in {4}s",
+                        new Object[]{retryCount, maxRetries, dest, e.getMessage(), waitTime});
                 Thread.sleep(TimeUnit.SECONDS.toMillis(waitTime));
             }
         }

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -18,7 +18,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;

--- a/src/main/java/hudson/plugins/s3/S3Profile.java
+++ b/src/main/java/hudson/plugins/s3/S3Profile.java
@@ -148,6 +148,22 @@ public class S3Profile {
                                     final boolean managedArtifacts,
                                     final boolean useServerSideEncryption,
                                     final boolean gzipFiles) throws IOException, InterruptedException {
+        return upload(run, bucketName, filePaths, fileNames, userMetadata, storageClass, selregion,
+                uploadFromSlave, managedArtifacts, useServerSideEncryption, gzipFiles, 30);
+    }
+
+    public List<FingerprintRecord> upload(Run<?, ?> run,
+                                    final String bucketName,
+                                    final List<FilePath> filePaths,
+                                    final List<String> fileNames,
+                                    final Map<String, String> userMetadata,
+                                    final String storageClass,
+                                    final String selregion,
+                                    final boolean uploadFromSlave,
+                                    final boolean managedArtifacts,
+                                    final boolean useServerSideEncryption,
+                                    final boolean gzipFiles,
+                                    final int uploadTimeout) throws IOException, InterruptedException {
         final List<FingerprintRecord> fingerprints = new ArrayList<>(fileNames.size());
 
         try {
@@ -174,18 +190,15 @@ public class S3Profile {
                             storageClass, selregion, useServerSideEncryption, getProxy(), usePathStyle);
                 }
 
-                final FingerprintRecord fingerprintRecord = repeat(maxUploadRetries, uploadRetryTime, dest, new Callable<FingerprintRecord>() {
-                    @Override
-                    public FingerprintRecord call() throws IOException, InterruptedException {
-                        final String md5 = invoke(uploadFromSlave, filePath, upload);
-                        return new FingerprintRecord(produced, bucketName, fileName, selregion, md5);
-                    }
+                final FingerprintRecord fingerprintRecord = repeat(maxUploadRetries, uploadRetryTime, dest, () -> {
+                    final String md5 = invoke(uploadFromSlave, filePath, upload);
+                    return new FingerprintRecord(produced, bucketName, fileName, selregion, md5);
                 });
 
                 fingerprints.add(fingerprintRecord);
             }
 
-            waitUploads(filePaths, uploadFromSlave);
+            waitUploads(filePaths, uploadFromSlave, uploadTimeout);
         } catch (InterruptedException | IOException exception) {
             cleanupUploads(filePaths, uploadFromSlave);
             throw exception;
@@ -204,9 +217,9 @@ public class S3Profile {
         }
     }
 
-    private void waitUploads(final List<FilePath> filePaths, boolean uploadFromSlave) throws InterruptedException, IOException {
+    private void waitUploads(final List<FilePath> filePaths, boolean uploadFromSlave, int uploadTimeout) throws InterruptedException, IOException {
         for (FilePath filePath : filePaths) {
-            invoke(uploadFromSlave, filePath, new S3WaitUploadCallable());
+            invoke(uploadFromSlave, filePath, new S3WaitUploadCallable(uploadTimeout));
         }
     }
 

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -117,6 +117,10 @@ public final class Uploads {
         return instance;
     }
 
+    void injectUpload(FilePath file, Upload upload) {
+        startedUploads.put(file, upload);
+    }
+
     public static class Metadata {
         private Consumer<PutObjectRequest.Builder> builder;
         private final Map<String, String> metadata;

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -34,6 +34,7 @@ public final class Uploads {
     private final transient Map<FilePath, Upload> startedUploads = new ConcurrentHashMap<>();
     private final ExecutorService executors;
     // This creates a cached thread pool with an upper bound (5) on threads to be spawned on demand.
+    // TODO: S3 client could use Virtual threads when baseline is Java 21
     {
         ThreadPoolExecutor pool = new ThreadPoolExecutor(
             5, 5,

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -4,7 +4,6 @@ import hudson.FilePath;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
-import software.amazon.awssdk.transfer.s3.model.FileUpload;
 import software.amazon.awssdk.transfer.s3.model.Upload;
 import software.amazon.awssdk.transfer.s3.model.UploadRequest;
 import software.amazon.awssdk.transfer.s3.progress.TransferListener;
@@ -14,9 +13,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -28,9 +30,22 @@ public final class Uploads {
     public static final int MULTIPART_UPLOAD_THRESHOLD = 16*1024*1024; // 16 MB
 
     private static transient volatile Uploads instance;
-    private final transient HashMap<FilePath, Upload> startedUploads = new HashMap<>();
-    private final ExecutorService executors = Executors.newScheduledThreadPool(1, new NamedThreadFactory(Executors.defaultThreadFactory(), Uploads.class.getName()));
-    private final transient HashMap<FilePath, InputStream> openedStreams = new HashMap<>();
+
+    private final transient Map<FilePath, Upload> startedUploads = new ConcurrentHashMap<>();
+    private final ExecutorService executors;
+    // This creates a cached thread pool with an upper bound (5) on threads to be spawned on demand.
+    {
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+            5, 5,
+            60L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            new NamedThreadFactory(Executors.defaultThreadFactory(), Uploads.class.getName())
+        );
+        pool.allowCoreThreadTimeOut(true);
+        executors = pool;
+    }
+
+    private final transient Map<FilePath, InputStream> openedStreams = new ConcurrentHashMap<>();
 
     public Upload startUploading(S3TransferManager manager, FilePath file, InputStream inputStream, String bucketName, String objectName, Metadata metadata, TransferListener listener) {
         UploadRequest.Builder request = UploadRequest.builder();

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -14,8 +14,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
@@ -43,16 +46,24 @@ public final class Uploads {
         return upload;
     }
 
-    public void finishUploading(FilePath filePath) throws InterruptedException {
+    public void finishUploading(FilePath filePath) throws InterruptedException, IOException {
         final Upload upload = startedUploads.remove(filePath);
         if (upload == null) {
             LOGGER.info("File: " + filePath.getName() + " already was uploaded");
             return;
         }
         try {
-            upload.completionFuture().join();
-        }
-        finally {
+            upload.completionFuture().get(1, TimeUnit.HOURS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            upload.completionFuture().cancel(true); // cancel the upload
+            throw e;
+        } catch (ExecutionException e) {
+            throw new IOException("Upload failed for: " + filePath.getName(), e.getCause());
+        } catch (TimeoutException e) {
+            upload.completionFuture().cancel(true);
+            throw new IOException("Upload timed out for: " + filePath.getName(), e);
+        } finally {
             closeStream(filePath);
         }
     }

--- a/src/main/java/hudson/plugins/s3/Uploads.java
+++ b/src/main/java/hudson/plugins/s3/Uploads.java
@@ -44,6 +44,8 @@ public final class Uploads {
         pool.allowCoreThreadTimeOut(true);
         executors = pool;
     }
+    public static final int DEFAULT_UPLOAD_TIMEOUT = 30;
+    public static final int MIN_UPLOAD_TIMEOUT = 5;
 
     private final transient Map<FilePath, InputStream> openedStreams = new ConcurrentHashMap<>();
 
@@ -62,13 +64,18 @@ public final class Uploads {
     }
 
     public void finishUploading(FilePath filePath) throws InterruptedException, IOException {
+        finishUploading(filePath, DEFAULT_UPLOAD_TIMEOUT);
+    }
+
+    public void finishUploading(FilePath filePath, int uploadTimeout) throws InterruptedException, IOException {
+        int effectiveTimeout = Math.max(uploadTimeout, MIN_UPLOAD_TIMEOUT);
         final Upload upload = startedUploads.remove(filePath);
         if (upload == null) {
             LOGGER.info("File: " + filePath.getName() + " already was uploaded");
             return;
         }
         try {
-            upload.completionFuture().get(1, TimeUnit.HOURS);
+            upload.completionFuture().get(effectiveTimeout, TimeUnit.MINUTES);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             upload.completionFuture().cancel(true); // cancel the upload
@@ -77,7 +84,7 @@ public final class Uploads {
             throw new IOException("Upload failed for: " + filePath.getName(), e.getCause());
         } catch (TimeoutException e) {
             upload.completionFuture().cancel(true);
-            throw new IOException("Upload timed out for: " + filePath.getName(), e);
+            throw new IOException("Upload timed out after " + effectiveTimeout + " minutes for: " + filePath.getName(), e);
         } finally {
             closeStream(filePath);
         }

--- a/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
@@ -10,6 +10,13 @@ import java.io.File;
 import java.io.IOException;
 
 public final class S3WaitUploadCallable implements MasterSlaveCallable<Void> {
+
+    private final int uploadTimeout;
+
+    public S3WaitUploadCallable(int uploadTimeout) {
+        this.uploadTimeout = uploadTimeout;
+    }
+
     @Override
     public Void invoke(File f, VirtualChannel channel) throws InterruptedException, IOException {
         invoke(new FilePath(f));
@@ -18,7 +25,7 @@ public final class S3WaitUploadCallable implements MasterSlaveCallable<Void> {
 
     @Override
     public Void invoke(FilePath file) throws InterruptedException, IOException {
-        Uploads.getInstance().finishUploading(file);
+        Uploads.getInstance().finishUploading(file, uploadTimeout);
         return null;
     }
 

--- a/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3WaitUploadCallable.java
@@ -7,16 +7,17 @@ import jenkins.security.Roles;
 import org.jenkinsci.remoting.RoleChecker;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class S3WaitUploadCallable implements MasterSlaveCallable<Void> {
     @Override
-    public Void invoke(File f, VirtualChannel channel) throws InterruptedException {
+    public Void invoke(File f, VirtualChannel channel) throws InterruptedException, IOException {
         invoke(new FilePath(f));
         return null;
     }
 
     @Override
-    public Void invoke(FilePath file) throws InterruptedException {
+    public Void invoke(FilePath file) throws InterruptedException, IOException {
         Uploads.getInstance().finishUploading(file);
         return null;
     }

--- a/src/test/java/hudson/plugins/s3/MinIOTest.java
+++ b/src/test/java/hudson/plugins/s3/MinIOTest.java
@@ -31,6 +31,7 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
 import hudson.plugins.copyartifact.LastCompletedBuildSelector;
+import org.jetbrains.annotations.NotNull;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -142,15 +143,13 @@ public class MinIOTest {
             r.jenkins.setNumExecutors(1);*/
             r.createOnlineSlave(Label.get("work"));
             createProfile();
-            createAndRunPublisher(r);
+            createAndRunPublisherWithCustomTimeout(r);
         });
     }
 
-    private static void createAndRunPublisher(final JenkinsRule r) throws Exception {
-        final FreeStyleProject job = r.createFreeStyleProject("publisherJob");
-        job.setAssignedLabel(Label.get("work"));
-        job.getBuildersList().add(new CreateFileBuilder("test.txt", FILE_CONTENT));
-        job.getPublishersList().add(new S3BucketPublisher("Local",
+    private static @NotNull S3BucketPublisher getS3BucketPublisher() {
+        return new S3BucketPublisher(
+                "Local",
                 Collections.singletonList(new Entry("test",
                         "test.txt",
                         "",
@@ -168,7 +167,17 @@ public class MinIOTest {
                 Collections.emptyList(),
                 true,
                 "FINE",
-                null, false));
+                null,
+                false);
+    }
+
+    private static void createAndRunPublisherWithCustomTimeout(final JenkinsRule r) throws Exception {
+        final FreeStyleProject job = r.createFreeStyleProject("publisherJob");
+        job.setAssignedLabel(Label.get("work"));
+        job.getBuildersList().add(new CreateFileBuilder("test.txt", FILE_CONTENT));
+        S3BucketPublisher publisher = getS3BucketPublisher();
+        publisher.setUploadTimeout(10);
+        job.getPublishersList().add(publisher);
         r.buildAndAssertSuccess(job);
     }
 
@@ -192,7 +201,7 @@ public class MinIOTest {
             r.createOnlineSlave(Label.get("copy"));
 
             createProfile();
-            createAndRunPublisher(r);
+            createAndRunPublisherWithCustomTimeout(r);
 
             FreeStyleProject job = r.createFreeStyleProject("copierJob");
             job.setAssignedLabel(Label.get("copy"));

--- a/src/test/java/hudson/plugins/s3/S3Test.java
+++ b/src/test/java/hudson/plugins/s3/S3Test.java
@@ -132,7 +132,8 @@ class S3Test {
                 Mockito.anyBoolean(),
                 Mockito.anyBoolean(),
                 Mockito.anyBoolean(),
-                Mockito.anyBoolean()
+                Mockito.anyBoolean(),
+                Mockito.anyInt()
         )).thenReturn(newArrayList(new FingerprintRecord(true, "bucket", "path", "eu-west-1", "xxxx")));
         return profile;
     }

--- a/src/test/java/hudson/plugins/s3/UploadsTest.java
+++ b/src/test/java/hudson/plugins/s3/UploadsTest.java
@@ -16,8 +16,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class UploadsTest {
 
@@ -72,6 +78,6 @@ class UploadsTest {
     }
 
     static Stream<Integer> timeouts() {
-        return Stream.of(1, 5, 10, 30, 45);
+        return Stream.of(1, 10, 30);
     }
 }

--- a/src/test/java/hudson/plugins/s3/UploadsTest.java
+++ b/src/test/java/hudson/plugins/s3/UploadsTest.java
@@ -1,0 +1,77 @@
+package hudson.plugins.s3;
+
+import hudson.FilePath;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.transfer.s3.model.CompletedUpload;
+import software.amazon.awssdk.transfer.s3.model.Upload;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class UploadsTest {
+
+    private Upload upload;
+    private Uploads uploads;
+    private FilePath file;
+
+    @BeforeEach
+    void setUp() {
+        upload = mock(Upload.class);
+        uploads = Uploads.getInstance();
+        file = new FilePath(new File("/tmp/uploads-test-dummy.txt"));
+    }
+
+    @Test
+    void finishUploading_succeedsWhenFutureCompletesNormally() {
+        CompletedUpload completedUpload = mock(CompletedUpload.class);
+        CompletableFuture<CompletedUpload> done = CompletableFuture.completedFuture(completedUpload);
+        when(upload.completionFuture()).thenReturn(done);
+
+        uploads.injectUpload(file, upload);
+        assertDoesNotThrow(() -> uploads.finishUploading(file, 30));
+    }
+
+    @Test
+    void finishUploading_throwsIOExceptionWhenUploadFails() {
+        CompletableFuture<CompletedUpload> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("S3 connection reset"));
+        when(upload.completionFuture()).thenReturn(failed);
+
+        uploads.injectUpload(file, upload);
+        IOException ex = assertThrows(IOException.class, () -> uploads.finishUploading(file, 15));
+        assertTrue(ex.getMessage().contains("Upload failed for"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("timeouts")
+    void finishUploading_cancelsExceptionallyOnTimeout(int timeout) throws ExecutionException, InterruptedException, TimeoutException {
+        // A future that never completes with a simulated timeout
+        @SuppressWarnings("unchecked")
+        CompletableFuture<CompletedUpload> neverDone = mock(CompletableFuture.class);
+        when(neverDone.get(anyLong(), any(TimeUnit.class)))
+                .thenThrow(new TimeoutException("Simulated timeout"));
+        when(neverDone.cancel(true)).thenReturn(true);
+        when(upload.completionFuture()).thenReturn(neverDone);
+
+        uploads.injectUpload(file, upload);
+        int timeoutToCheckFor = Math.max(timeout, Uploads.MIN_UPLOAD_TIMEOUT);
+        IOException ex = assertThrows(IOException.class, () -> uploads.finishUploading(file, timeout));
+        assertTrue(ex.getMessage().contains("Upload timed out after " + timeoutToCheckFor + " minutes"));
+        verify(neverDone).cancel(true);
+    }
+
+    static Stream<Integer> timeouts() {
+        return Stream.of(1, 5, 10, 30, 45);
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Timeout is now configurable with 30 mins default, and 5 mins lower bound.

### Testing done
- Added unit tests verifying timeouts
- Manually tested with (and without) `uploadTimeout: 10` parameter for uploading to s3 bucket - exhibits correct behaviour
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
