### PR TITLE
[JENKINS-76422] Fix useServerSideEncryption using SSE-C header instead of SSE-S3

### DIFF
--- a/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3BaseUploadCallable.java
@@ -8,6 +8,7 @@ import hudson.plugins.s3.Destination;
 import hudson.remoting.VirtualChannel;
 import hudson.util.Secret;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public abstract class S3BaseUploadCallable extends S3Callable<String> {
                 metadata.storageClass(storageClass);
             }
             if (useServerSideEncryption) {
-                metadata.sseCustomerAlgorithm("AES256");
+                metadata.serverSideEncryption(ServerSideEncryption.AES256);
             }
         };
         Uploads.Metadata metadata = new Uploads.Metadata(builder);


### PR DESCRIPTION
Hi, thanks for maintaining this plugin!

I ran into an issue after upgrading to v505+ where enabling "Server side encryption" in job config causes the following error:

```
S3Exception: Requests specifying Server Side Encryption with Customer provided keys must provide an appropriate secret key. (Service: S3, Status Code: 400)
```

It looks like `S3BaseUploadCallable.buildMetadata()` calls `sseCustomerAlgorithm("AES256")`, which sets the SSE-C header (`x-amz-server-side-encryption-customer-algorithm`). SSE-C requires a customer-provided key, but the plugin doesn't send one.

I believe this was an unintended change during the SDK v1 to v2 migration. The original intent was SSE-S3 (AWS-managed keys), not SSE-C (customer-provided keys).

This PR replaces:

```diff
- metadata.sseCustomerAlgorithm("AES256");
+ metadata.serverSideEncryption(ServerSideEncryption.AES256);
```

This sets the correct `x-amz-server-side-encryption: AES256` header for SSE-S3.

Let me know if anything needs to be changed. Thanks!