### PR TITLE
Remove commons-lang2 usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
 
     <developers>

--- a/src/main/java/hudson/plugins/s3/ClientHelper.java
+++ b/src/main/java/hudson/plugins/s3/ClientHelper.java
@@ -21,8 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
-
 public class ClientHelper {
     public final static String DEFAULT_AMAZON_S3_REGION_NAME = System.getProperty(
             "hudson.plugins.s3.DEFAULT_AMAZON_S3_REGION", Region.US_EAST_1.id());
@@ -31,7 +29,7 @@ public class ClientHelper {
 
     static {
         try {
-            ENDPOINT_URI = isNotEmpty(ENDPOINT) ? new URI(ENDPOINT) : null;
+            ENDPOINT_URI = (ENDPOINT != null && !ENDPOINT.isEmpty()) ? new URI(ENDPOINT) : null;
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
@@ -136,7 +134,7 @@ public class ClientHelper {
         if (shouldUseProxy(proxy, serviceEndpoint)) {
             software.amazon.awssdk.http.apache.ProxyConfiguration.Builder proxyBuilder = software.amazon.awssdk.http.apache.ProxyConfiguration.builder()
                     .endpoint(new URI("http", null, proxy.getName(), proxy.getPort(), null, null, null));
-            if (isNotEmpty(proxy.getUserName())) {
+            if (proxy.getUserName() != null && !proxy.getUserName().isEmpty()) {
                 proxyBuilder
                         .username(proxy.getUserName())
                         .password(proxy.getPassword());
@@ -154,7 +152,7 @@ public class ClientHelper {
         if (shouldUseProxy(proxy, serviceEndpoint)) {
             software.amazon.awssdk.http.nio.netty.ProxyConfiguration.Builder proxyBuilder = software.amazon.awssdk.http.nio.netty.ProxyConfiguration.builder()
                     .host(proxy.getName()).port(proxy.getPort());
-            if (isNotEmpty(proxy.getUserName())) {
+            if (proxy.getUserName() != null && !proxy.getUserName().isEmpty()) {
                 proxyBuilder
                         .username(proxy.getUserName())
                         .password(proxy.getPassword());

--- a/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
+++ b/src/main/java/hudson/plugins/s3/S3ArtifactsAction.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 @ExportedBean
 public class S3ArtifactsAction implements RunAction2 {

--- a/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
+++ b/src/main/java/hudson/plugins/s3/S3BucketPublisher.java
@@ -34,7 +34,7 @@ import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
+import java.util.Objects;
 import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -254,7 +254,7 @@ public final class S3BucketPublisher extends Recorder implements SimpleBuildStep
 
     private void log(final Level level, final PrintStream logger, final String message) {
         if(level.intValue() >= consoleLogLevel.intValue()) {
-            logger.println(StringUtils.defaultString(getDescriptor().getDisplayName()) + ' ' + message);
+            logger.println(Objects.toString(getDescriptor().getDisplayName(), "") + ' ' + message);
         }
     }
 

--- a/src/main/java/hudson/plugins/s3/callable/S3Callable.java
+++ b/src/main/java/hudson/plugins/s3/callable/S3Callable.java
@@ -14,8 +14,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
-
 abstract class S3Callable<T> implements FileCallable<T> {
     private static final long serialVersionUID = 1L;
 
@@ -50,7 +48,7 @@ abstract class S3Callable<T> implements FileCallable<T> {
                         useRole,
                         region,
                         proxy,
-                        isNotEmpty(customEndpoint) ? new URI(customEndpoint) : null,
+                        (customEndpoint != null && !customEndpoint.isEmpty()) ? new URI(customEndpoint) : null,
                         (long)Uploads.MULTIPART_UPLOAD_THRESHOLD,
                         usePathStyle);
                 transferManagers.put(uniqueKey, S3TransferManager.builder().s3Client(client).build());


### PR DESCRIPTION
Commons-lang2 will be soon removed from Jenkins core https://github.com/jenkinsci/jenkins/pull/26105; remove the lang2 usages from here to prepare. Usages are simple hence replacing with just jdk apis.